### PR TITLE
fix: require valid subscription before unlimited access

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
                             <li>Clear Action Recommendations</li>
                             <li>See If This Actually Works</li>
                         </ul>
-                        <a href="https://tally.so/r/mJbgaz" class="pricing-button">Try It Free (No BS)</a>
+                        <a href="https://tally.so/r/me8pJE" class="pricing-button">Try It Free (No BS)</a>
                     </div>
                     
                     <div class="pricing-card featured">

--- a/submit-analysis.html
+++ b/submit-analysis.html
@@ -118,7 +118,7 @@
             free: {
                 name: 'Free Reality Check',
                 description: 'Get 1 honest analysis per month to see what this AI bestie is all about.',
-                tallyUrl: 'https://tally.so/r/mJbgaz',
+                tallyUrl: 'https://tally.so/r/me8pJE',
                 limit: 1
             },
             unlimited: {
@@ -148,7 +148,7 @@
                 if (submitted) {
                     email = prompt('Please enter your email to activate your subscription:');
                 } else {
-                    email = prompt('Please enter your email to access your unlimited analysis:');
+                    email = prompt('Please enter your email to access your analysis portal:');
                 }
                 if (!email || !email.includes('@')) {
                     alert('Valid email required');
@@ -163,14 +163,6 @@
             // Handle new subscription activation
             if (submitted) {
                 activateSubscription();
-            } else {
-                // For existing users coming from "already subscribed" link, 
-                // assume they have unlimited unless proven otherwise
-                if (!userState.subscriptionActive && userState.plan === 'free') {
-                    userState.plan = 'unlimited';
-                    userState.subscriptionActive = true;
-                    saveUserData();
-                }
             }
 
             updateDisplay();


### PR DESCRIPTION
## Summary
- remove automatic unlimited upgrade from "already subscribed" portal access
- clarify email prompt for portal access
- align free reality check with "Am I Delusional?" quiz's tally form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e78b5a06083269a5803d4a13e7743