### PR TITLE
Rename quiz to analysis in CTA and thank-you pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
             <div class="container">
                 <h1>Your AI Bestie with a PhD</h1>
                 <p class="subtitle">Stop wondering "what does this even mean??" Upload your confusing-ass messages and get brutally honest AI analysis to spot red flags, decode the BS, and finally see what's REALLY going on. Because bestie, we both know you already know.</p>
-                <a href="https://tally.so/r/me8pJE" class="cta-button" target="_blank">Take Free "Am I Delusional?" Quiz</a>
+                <a href="https://tally.so/r/me8pJE" class="cta-button" target="_blank">Take the Free "Am I Delusional?" Analysis</a>
                 <p class="secondary-cta">or <a href="submit-analysis.html" style="color: var(--medium-gray); text-decoration: underline; font-weight: normal;">already subscribed? analyze your messages →</a></p>
             </div>
         </section>

--- a/thank-you.html
+++ b/thank-you.html
@@ -184,12 +184,12 @@
         <div class="thank-you-card">
             <span class="emoji">🎉</span>
             <h1>Thank You!</h1>
-            <p class="subtitle">Your clarity quiz results are being prepared. We'll send your personalized insights and next steps to your inbox within the next few minutes.</p>
+            <p class="subtitle">Your clarity analysis results are being prepared. We'll send your personalized insights and next steps to your inbox within the next few minutes.</p>
             
             <div class="next-steps">
                 <h3>What Happens Next:</h3>
                 <ul>
-                    <li>Check your email for personalized quiz results</li>
+                    <li>Check your email for personalized analysis results</li>
                     <li>Get weekly bestie wisdom in our newsletter</li>
                     <li>Learn to spot red flags and trust your intuition</li>
                     <li>Ready for deeper insights? Try our message analysis</li>
@@ -209,7 +209,7 @@
     
     <script>
         // Simple analytics - track thank you page views
-        console.log('Thank you page loaded - quiz completed');
+        console.log('Thank you page loaded - analysis completed');
         
         // Optional: Add any tracking code here (Google Analytics, etc.)
     </script>


### PR DESCRIPTION
## Summary
- update hero call-to-action to "Take the Free 'Am I Delusional?' Analysis"
- switch thank-you page wording and logging from quiz to analysis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892f2b5cc948326b99402c6c57a281f