### PR TITLE
Add serverless Stripe subscription check and portal integration

### DIFF
--- a/api/check-subscription.js
+++ b/api/check-subscription.js
@@ -1,0 +1,27 @@
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+
+module.exports = async (req, res) => {
+  const email = req.query.email || (req.body && req.body.email);
+  if (!email) {
+    return res.status(400).json({ error: 'Email required' });
+  }
+
+  try {
+    const customers = await stripe.customers.list({ email, limit: 1 });
+    if (!customers.data.length) {
+      return res.json({ active: false });
+    }
+
+    const subscriptions = await stripe.subscriptions.list({
+      customer: customers.data[0].id,
+      status: 'active',
+      limit: 1
+    });
+
+    const active = subscriptions.data.length > 0;
+    res.json({ active });
+  } catch (err) {
+    console.error('Stripe check failed', err);
+    res.status(500).json({ error: 'Internal error' });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "scripts": {
     "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "stripe": "^12.17.0"
   }
 }

--- a/submit-analysis.html
+++ b/submit-analysis.html
@@ -97,7 +97,7 @@
             subscriptionActive: false
         };
 
-        function init() {
+        async function init() {
             const params = new URLSearchParams(window.location.search);
             const submitted = params.get('submitted') === 'true';
             let email = params.get('email') || params.get('customer_email');
@@ -124,6 +124,13 @@
                 activateSubscription();
             }
 
+            if (!userState.subscriptionActive) {
+                await checkSubscription();
+                if (userState.subscriptionActive) {
+                    return;
+                }
+            }
+
             updateDisplay();
         }
 
@@ -136,6 +143,21 @@
                 } catch (e) {
                     userState = { email: userState.email, subscriptionActive: false };
                 }
+            }
+        }
+
+        async function checkSubscription() {
+            try {
+                const res = await fetch(`/api/check-subscription?email=${encodeURIComponent(userState.email)}`);
+                if (!res.ok) return;
+                const data = await res.json();
+                userState.subscriptionActive = data.active;
+                saveUserData();
+                if (data.active) {
+                    accessAnalysis();
+                }
+            } catch (e) {
+                console.error('Subscription check failed', e);
             }
         }
 


### PR DESCRIPTION
## Summary
- add `/api/check-subscription` endpoint to verify active Stripe subscriptions by email
- query endpoint during portal init and redirect active users straight to Tally form
- declare Stripe dependency for new server-side check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893005d37148326bbc2a100daed0092