### PR TITLE
Improve subscription check reliability and email storage

### DIFF
--- a/submit-analysis.html
+++ b/submit-analysis.html
@@ -116,6 +116,7 @@
                 }
             }
 
+            email = email.trim().toLowerCase();
             userState.email = email;
             loadUserData();
 
@@ -124,18 +125,17 @@
                 activateSubscription();
             }
 
-            if (!userState.subscriptionActive) {
-                await checkSubscription();
-                if (userState.subscriptionActive) {
-                    return;
-                }
+            await checkSubscription();
+            if (userState.subscriptionActive) {
+                accessAnalysis();
+                return;
             }
 
             updateDisplay();
         }
 
         function loadUserData() {
-            const saved = localStorage.getItem(`user_${userState.email}`);
+            const saved = localStorage.getItem(`user_${userState.email.toLowerCase()}`);
             if (saved) {
                 try {
                     const parsed = JSON.parse(saved);
@@ -149,20 +149,24 @@
         async function checkSubscription() {
             try {
                 const res = await fetch(`/.netlify/functions/check-subscription?email=${encodeURIComponent(userState.email)}`);
-                if (!res.ok) return;
+                if (!res.ok) {
+                    throw new Error('Network response was not ok');
+                }
                 const data = await res.json();
                 userState.subscriptionActive = data.active;
                 saveUserData();
-                if (data.active) {
-                    accessAnalysis();
-                }
             } catch (e) {
                 console.error('Subscription check failed', e);
+                if (userState.subscriptionActive) {
+                    alert('We couldn\'t verify your subscription with the server, but your local access is active. If you encounter issues, please contact support.');
+                } else {
+                    alert('Unable to verify your subscription. Please try again or contact support if the issue persists.');
+                }
             }
         }
 
         function saveUserData() {
-            localStorage.setItem(`user_${userState.email}`, JSON.stringify({
+            localStorage.setItem(`user_${userState.email.toLowerCase()}`, JSON.stringify({
                 subscriptionActive: userState.subscriptionActive
             }));
         }


### PR DESCRIPTION
## Summary
- Normalize emails to lowercase before interacting with localStorage to avoid case-sensitive mismatches
- Always run `checkSubscription` on load and alert users on network errors so they know to retry or contact support
- Fall back to local subscription state and continue to analysis when the server check fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893112a48448326a12d023cd9232b83