### PR TITLE
Add helper for email validation

### DIFF
--- a/submit-analysis.html
+++ b/submit-analysis.html
@@ -97,15 +97,23 @@
             subscriptionActive: false
         };
 
+        function isValidEmail(email) {
+            if (!email) return false;
+            const normalized = String(email).trim().toLowerCase();
+            const invalidPlaceholders = ['{checkout_session_customer_email}', 'undefined', 'null'];
+            if (invalidPlaceholders.includes(normalized)) {
+                return false;
+            }
+            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            return emailRegex.test(normalized);
+        }
+
         async function init() {
             const params = new URLSearchParams(window.location.search);
             const submitted = params.get('submitted') === 'true';
             let email = params.get('email') || params.get('customer_email');
 
-            // Strict email validation
-            if (!email ||
-                email === '{CHECKOUT_SESSION_CUSTOMER_EMAIL}' ||
-                !email.includes('@')) {
+            if (!isValidEmail(email)) {
                 alert('Invalid email. Please purchase a subscription.');
                 window.location.href = PLANS.unlimited.stripeUrl;
                 return;


### PR DESCRIPTION
## Summary
- add `isValidEmail` helper rejecting placeholders and ensuring structure via regex
- validate emails in `init` using `isValidEmail`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c77753f48326b17cf767078e6523