### PR TITLE
Handle missing Stripe key in subscription functions

### DIFF
--- a/netlify/functions/activate-subscription.js
+++ b/netlify/functions/activate-subscription.js
@@ -1,6 +1,14 @@
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
-
 exports.handler = async (event) => {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    const message = 'Stripe secret key is not configured';
+    console.error(message);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: message })
+    };
+  }
+
+  const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
   let email;
   try {
     ({ email } = JSON.parse(event.body || '{}'));

--- a/netlify/functions/check-subscription.js
+++ b/netlify/functions/check-subscription.js
@@ -1,6 +1,14 @@
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
-
 exports.handler = async (event) => {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    const message = 'Stripe secret key is not configured';
+    console.error(message);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: message })
+    };
+  }
+
+  const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
   const email =
     (event.queryStringParameters && event.queryStringParameters.email) ||
     (event.body && JSON.parse(event.body).email);


### PR DESCRIPTION
## Summary
- check for `STRIPE_SECRET_KEY` before initializing Stripe
- return a 500 response with a descriptive error when the key is absent

## Testing
- `npm test`
- `STRIPE_SECRET_KEY="" node -e "require('./netlify/functions/check-subscription.js').handler({queryStringParameters:{email:'test@example.com'}}).then(r=>console.log(r))"`
- `STRIPE_SECRET_KEY="" node -e "require('./netlify/functions/activate-subscription.js').handler({body:JSON.stringify({email:'test@example.com'})}).then(r=>console.log(r))"`


------
https://chatgpt.com/codex/tasks/task_e_6893c77898e08326b19db72b10daf3f1