### PR TITLE
refactor: add stripe utils

### DIFF
--- a/netlify/functions/check-subscription.js
+++ b/netlify/functions/check-subscription.js
@@ -1,14 +1,6 @@
-exports.handler = async (event) => {
-  if (!process.env.STRIPE_SECRET_KEY) {
-    const message = 'Stripe secret key is not configured';
-    console.error(message);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: message })
-    };
-  }
+const { getActiveSubscription } = require('./stripe-utils');
 
-  const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+exports.handler = async (event) => {
   const email =
     (event.queryStringParameters && event.queryStringParameters.email) ||
     (event.body && JSON.parse(event.body).email);
@@ -16,35 +8,25 @@ exports.handler = async (event) => {
   if (!email) {
     return {
       statusCode: 400,
-      body: JSON.stringify({ error: 'Email required' })
+      body: JSON.stringify({ error: 'Email required' }),
     };
   }
 
   try {
-    const customers = await stripe.customers.list({ email, limit: 1 });
-    if (!customers.data.length) {
-      return {
-        statusCode: 200,
-        body: JSON.stringify({ active: false })
-      };
-    }
-
-    const subscriptions = await stripe.subscriptions.list({
-      customer: customers.data[0].id,
-      status: 'active',
-      limit: 1
-    });
-
-    const active = subscriptions.data.length > 0;
+    const subscription = await getActiveSubscription(email);
     return {
       statusCode: 200,
-      body: JSON.stringify({ active })
+      body: JSON.stringify({ active: Boolean(subscription) }),
     };
   } catch (err) {
-    console.error('Stripe check failed', err);
+    console.error('Stripe query failed', err);
+    const message =
+      err.message === 'Stripe secret key is not configured'
+        ? err.message
+        : 'Internal error';
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: 'Internal error' })
+      body: JSON.stringify({ error: message }),
     };
   }
 };

--- a/netlify/functions/stripe-utils.js
+++ b/netlify/functions/stripe-utils.js
@@ -1,0 +1,24 @@
+const Stripe = require('stripe');
+
+function getStripe() {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error('Stripe secret key is not configured');
+  }
+  return Stripe(process.env.STRIPE_SECRET_KEY);
+}
+
+async function getActiveSubscription(email) {
+  const stripe = getStripe();
+  const customers = await stripe.customers.list({ email, limit: 1 });
+  if (!customers.data.length) {
+    return null;
+  }
+  const subscriptions = await stripe.subscriptions.list({
+    customer: customers.data[0].id,
+    status: 'active',
+    limit: 1,
+  });
+  return subscriptions.data[0] || null;
+}
+
+module.exports = { getActiveSubscription };


### PR DESCRIPTION
## Summary
- add reusable Stripe `getActiveSubscription` helper
- refactor subscription functions to use helper and standardize responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941fdb7b388326b68b5b8c4ac970dc