### PR TITLE
Embed Jotform payment form on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,9 +594,16 @@
                             <li>Priority Support</li>
                             <li>Cancel Anytime (but you won't want to)</li>
                         </ul>
-                        <a href="https://buy.stripe.com/9B64gyajP35Qaoq6SR9EI0d" class="pricing-button" target="_blank" rel="noopener">Get Unlimited Analysis</a>
+                        <a href="#checkout" class="pricing-button">Get Unlimited Analysis</a>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <section id="checkout" class="analysis-section">
+            <div class="container">
+                <h2>Complete Your Purchase</h2>
+                <script type="text/javascript" src="https://pci.jotform.com/jsform/252205842827054"></script>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Replace Stripe purchase link with anchor to embedded Jotform checkout
- Add checkout section with Jotform form to handle payments via Stripe

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c18dd21408326b24d65cecd661c81