### PR TITLE
Restore Free Analysis form on homepage

### DIFF
--- a/Healing-Your-Patterns.html
+++ b/Healing-Your-Patterns.html
@@ -329,7 +329,7 @@
                     <div class="cta-section">
                         <h3>Ready to Break the Cycle?</h3>
                         <p>Get unlimited message analysis and start healing the patterns holding you back.</p>
-                        <a href="https://buy.stripe.com/9B64gyajP35Qaoq6SR9EI0d" class="cta-button" target="_blank" rel="noopener">Unlock Unlimited Analysis – $12/mo</a>
+                        <a href="index.html#checkout" class="cta-button">Unlock Unlimited Analysis – $12/mo</a>
                     </div>
                 </div>
             </div>

--- a/Trust-Your-Intuition.html
+++ b/Trust-Your-Intuition.html
@@ -407,7 +407,7 @@
                     <div class="cta-section">
                         <h3>Ready to Trust Your Gut?</h3>
                         <p>Get unlimited message analysis to learn the difference between intuition and anxiety.</p>
-                        <a href="https://buy.stripe.com/9B64gyajP35Qaoq6SR9EI0d" class="cta-button" target="_blank" rel="noopener">Unlock Unlimited Analysis – $12/mo</a>
+                        <a href="index.html#checkout" class="cta-button">Unlock Unlimited Analysis – $12/mo</a>
                     </div>
                 </div>
             </div>

--- a/blog.html
+++ b/blog.html
@@ -116,7 +116,7 @@
                 <div class="cta-section">
                     <h2>Want Clarity on Your Own Messages?</h2>
                     <p>Get unlimited message analysis for just $12/month.</p>
-                    <a href="https://buy.stripe.com/9B64gyajP35Qaoq6SR9EI0d" class="cta-button" target="_blank" rel="noopener">Unlock Unlimited Analysis – $12/mo</a>
+                    <a href="index.html#checkout" class="cta-button">Unlock Unlimited Analysis – $12/mo</a>
                 </div>
             </div>
         </section>

--- a/ignoring-red-flags.html
+++ b/ignoring-red-flags.html
@@ -387,7 +387,7 @@
                     <div class="cta-section">
                         <h3>Ready to Break Free?</h3>
                         <p>Get personalized breakdowns of your messages and spot manipulation tactics before you get trapped.</p>
-                        <a href="https://buy.stripe.com/9B64gyajP35Qaoq6SR9EI0d" class="cta-button" target="_blank" rel="noopener">Unlock Unlimited Analysis – $12/mo</a>
+                        <a href="index.html#checkout" class="cta-button">Unlock Unlimited Analysis – $12/mo</a>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -557,6 +557,7 @@
                         <li><a href="#analysis">Analysis</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="about.html">About</a></li>
+                        <li><a href="#free-analysis">Free Analysis</a></li>
                     </ul>
                 </nav>
             </div>
@@ -568,8 +569,15 @@
             <div class="container">
                 <h1>Your AI Bestie with a PhD</h1>
                 <p class="subtitle">Stop wondering "what does this even mean??" Upload your confusing-ass messages and get brutally honest AI analysis to spot red flags, decode the BS, and finally see what's REALLY going on. Because bestie, we both know you already know.</p>
+                <a href="#checkout" class="cta-button">Get Unlimited Analysis</a>
+                <p class="secondary-cta"><a href="https://form.jotform.com/252235665920155" style="color: var(--medium-gray); text-decoration: underline; font-weight: normal;">already subscribed? analyze your messages →</a></p>
+            </div>
+        </section>
 
-                <p class="secondary-cta">or <a href="https://form.jotform.com/252235665920155" style="color: var(--medium-gray); text-decoration: underline; font-weight: normal;">already subscribed? analyze your messages →</a></p>
+        <section id="free-analysis" class="analysis-section">
+            <div class="container">
+                <h2>Free "Am I Delusional?" Analysis</h2>
+                <script type="text/javascript" src="https://form.jotform.com/jsform/252205735289057"></script>
             </div>
         </section>
 
@@ -594,9 +602,16 @@
                             <li>Priority Support</li>
                             <li>Cancel Anytime (but you won't want to)</li>
                         </ul>
-                        <a href="https://buy.stripe.com/9B64gyajP35Qaoq6SR9EI0d" class="pricing-button" target="_blank" rel="noopener">Get Unlimited Analysis</a>
+                        <a href="#checkout" class="pricing-button">Get Unlimited Analysis</a>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <section id="checkout" class="analysis-section">
+            <div class="container">
+                <h2>Complete Your Purchase</h2>
+                <script type="text/javascript" src="https://pci.jotform.com/jsform/252205842827054"></script>
             </div>
         </section>
 

--- a/missing-green-flags.html
+++ b/missing-green-flags.html
@@ -346,7 +346,7 @@
                     <div class="cta-section">
                         <h3>Ready to Break the Pattern?</h3>
                         <p>Get unlimited message analysis and learn to spot both red and green flags in your actual conversations.</p>
-                        <a href="https://buy.stripe.com/9B64gyajP35Qaoq6SR9EI0d" class="cta-button" target="_blank" rel="noopener">Unlock Unlimited Analysis – $12/mo</a>
+                        <a href="index.html#checkout" class="cta-button">Unlock Unlimited Analysis – $12/mo</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add simple top navigation link for the free "Am I Delusional?" analysis while shifting the hero CTA to promote the unlimited subscription
- Update upsell buttons across blog and guidance pages to point to the embedded checkout section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c18dd21408326b24d65cecd661c81