### PR TITLE
Replace Free Analysis section with external link

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,7 +557,7 @@
                         <li><a href="#analysis">Analysis</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="about.html">About</a></li>
-                        <li><a href="#free-analysis">Free Analysis</a></li>
+                        <li><a href="https://form.jotform.com/252205735289057">Free Analysis</a></li>
                     </ul>
                 </nav>
             </div>
@@ -572,14 +572,6 @@
 
             </div>
         </section>
-
-        <section id="free-analysis" class="analysis-section">
-            <div class="container">
-                <h2>Free "Am I Delusional?" Analysis</h2>
-                <script type="text/javascript" src="https://form.jotform.com/jsform/252205735289057"></script>
-            </div>
-        </section>
-
         <section id="analysis" class="analysis-section">
             <div class="container">
                 <h2>Analyze Your Messages</h2>


### PR DESCRIPTION
## Summary
- Link "Free Analysis" in navigation directly to Jotform instead of in-page anchor.
- Remove obsolete free-analysis section and embedded Jotform script.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c2a599d548326a092ec43fb79a2ae