### PR TITLE
Improve newsletter signup accessibility on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,19 @@
             margin: 0 auto;
             padding: 0 20px;
         }
-        
+
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0 0 0 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
         /* Header */
         header {
             background: var(--white);
@@ -469,13 +481,7 @@
                 font-size: 1rem;
                 padding: 0 15px;
             }
-            
-            .newsletter-form {
-                flex-direction: column;
-                max-width: 300px;
-                gap: 1rem;
-            }
-            
+
             .newsletter-form input,
             .newsletter-form button {
                 padding: 1.25rem;
@@ -542,6 +548,17 @@
             .cta-button {
                 margin: 0 10px;
                 padding: 1rem 1.25rem;
+            }
+
+            .newsletter-form {
+                display: flex;
+                flex-direction: column;
+                gap: 1rem;
+            }
+
+            .newsletter-form input,
+            .newsletter-form button {
+                width: 100%;
             }
         }
     </style>
@@ -648,13 +665,14 @@
                 <!-- Newsletter Form with Hidden Iframe -->
                 <div class="newsletter-form-container">
                     <form class="newsletter-form" id="newsletter-form" action="https://assets.mailerlite.com/jsonp/1594871/forms/160002022910723398/subscribe" method="post" target="hidden-iframe">
-                        <input type="email" name="fields[email]" placeholder="Your email address" required>
+                        <label for="newsletter-email" class="visually-hidden">Email address</label>
+                        <input type="email" id="newsletter-email" name="fields[email]" placeholder="Your email address" required>
                         <input type="hidden" name="ml-submit" value="1">
                         <input type="hidden" name="anticsrf" value="true">
                         <button type="submit">Subscribe</button>
                     </form>
-                    
-                    <div class="newsletter-success" id="newsletter-success" style="display: none; text-align: center; background: rgba(34, 197, 94, 0.1); border: 2px solid #22c55e; border-radius: 8px; padding: 1.5rem; margin-top: 1rem;">
+
+                    <div class="newsletter-success" id="newsletter-success" aria-live="polite" role="status" style="display: none; text-align: center; background: rgba(34, 197, 94, 0.1); border: 2px solid #22c55e; border-radius: 8px; padding: 1.5rem; margin-top: 1rem;">
                         <h3 style="color: #22c55e; margin-bottom: 0.5rem;">🎉 You're In!</h3>
                         <p style="color: #1f2937; margin: 0;">Thanks for subscribing! Check your inbox for weekly bestie wisdom.</p>
                     </div>


### PR DESCRIPTION
## Summary
- Add visually hidden label and `aria-live` status to newsletter form for better screen reader support
- Stack email input and subscribe button on small screens and make them full width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eae1ea1888326af1021c9f2c1f22a