### PR TITLE
Remove automatic hero image from article layout

### DIFF
--- a/are-we-dating-the-same-guy.html
+++ b/are-we-dating-the-same-guy.html
@@ -19,11 +19,6 @@
             margin: 0 auto;
             padding: 20px;
         }
-        img.hero {
-            width: 100%;
-            height: auto;
-            border-radius: 8px;
-        }
         .intro-image {
             max-width: 100%;
             height: auto;
@@ -74,7 +69,6 @@
 </head>
 <body>
     <main class="container">
-        <img src="assets/images/even-twin-sisters-have-problems-with-relations.jpg" alt="Supportive group" class="hero" />
         <h1>Are We Dating the Same Guy… Again?</h1>
         <p class="meta">Read time: 6 min</p>
         <p>The Facebook group started as a whisper – a space for women to quietly compare notes when something felt off. Within months it exploded, revealing how often we find ourselves caught in the same recycled stories, wondering if we’re the only ones seeing the pattern.</p>


### PR DESCRIPTION
## Summary
- Stop rendering a fixed hero image above article titles
- Allow each article's HTML to manage its own images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f434911288326a7e69335162f011b