### PR TITLE
Remove automatic hero image from blog posts

### DIFF
--- a/are-we-dating-the-same-guy.html
+++ b/are-we-dating-the-same-guy.html
@@ -11,7 +11,6 @@
 </head>
 <body>
     <main class="blog-post">
-        <img src="assets/images/even-twin-sisters-have-problems-with-relations.jpg" alt="Supportive group" class="hero" />
         <h1>Are We Dating the Same Guy… Again?</h1>
         <p class="meta">Read time: 6 min</p>
         <p>The Facebook group started as a whisper – a space for women to quietly compare notes when something felt off. Within months it exploded, revealing how often we find ourselves caught in the same recycled stories, wondering if we’re the only ones seeing the pattern.</p>


### PR DESCRIPTION
## Summary
- delete auto-rendered hero image above the blog post title

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f47abd6dc8326a983dc0b577a3421