### PR TITLE
Add CTA button with newsletter perk and mobile-visible tagline

### DIFF
--- a/About.html
+++ b/About.html
@@ -183,13 +183,29 @@
                 text-align: center;
             }
         }
+        .site-tagline {
+            display: block !important;
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: var(--dark-gray, #1f2937);
+            text-align: center;
+            margin-top: 6px;
+            line-height: 1.3;
+        }
+
+        @media (min-width: 768px) {
+            .site-tagline { font-size: 1rem; }
+        }
     </style>
 </head>
 <body>
     <header>
         <div class="container">
             <div class="header-content">
-                <a href="index.html" class="logo">Seen and Red</a>
+                <div>
+                    <a href="index.html" class="logo">Seen and Red</a>
+                    <p class="site-tagline">Your AI Bestie with a PhD</p>
+                </div>
                 <nav>
                     <ul>
                         <li><a href="index.html">Home</a></li>

--- a/Healing-Your-Patterns.html
+++ b/Healing-Your-Patterns.html
@@ -11,7 +11,10 @@
 <body>
     <header>
         <div class="header-content">
-            <a href="index.html" class="logo">Seen and Red</a>
+            <div>
+                <a href="index.html" class="logo">Seen and Red</a>
+                <p class="site-tagline">Your AI Bestie with a PhD</p>
+            </div>
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>
@@ -58,11 +61,23 @@
                         <p><strong>Key insight:</strong> You don't choose your patterns consciously. They're automatic responses your nervous system learned to keep you safe (or get love) in your original environment.</p>
                     </div>
 
-                    <div class="cta-section">
-                        <h3>Ready to Break the Cycle?</h3>
-                        <p>Get unlimited message analysis and start healing the patterns holding you back.</p>
-                        <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="cta-button" target="_blank" rel="nofollow noopener">Unlock Unlimited Analysis – $12/mo</a>
-                    </div>
+                    <section class="cta-upsell" role="region" aria-labelledby="cta-upsell-heading">
+                        <p id="cta-upsell-heading" class="cta-upsell__heading">Want Clarity on Your Own Messages?</p>
+                        <p class="cta-upsell__subcopy">
+                            Get unlimited message analysis for just $12/month — plus a free subscription to the Seen &amp; Red Dispatch with insider tips, real dating stories, and red-flag breakdowns.
+                        </p>
+
+                        <a
+                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            class="cta-upsell__button"
+                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            rel="nofollow noopener"
+                        >
+                            Unlock Unlimited Analysis — $12/mo
+                        </a>
+
+                        <p class="cta-upsell__perk">Includes our weekly Seen &amp; Red Dispatch newsletter. Unsubscribe anytime.</p>
+                    </section>
                 </div>
             </div>
         </article>

--- a/Privacy.html
+++ b/Privacy.html
@@ -197,12 +197,29 @@
                 padding: 0 15px;
             }
         }
+
+        .site-tagline {
+            display: block !important;
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: var(--dark-gray, #1f2937);
+            text-align: center;
+            margin-top: 6px;
+            line-height: 1.3;
+        }
+
+        @media (min-width: 768px) {
+            .site-tagline { font-size: 1rem; }
+        }
     </style>
 </head>
 <body>
     <header>
         <div class="header-content">
-            <a href="index.html" class="logo">Seen and Red</a>
+            <div>
+                <a href="index.html" class="logo">Seen and Red</a>
+                <p class="site-tagline">Your AI Bestie with a PhD</p>
+            </div>
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>

--- a/Trust-Your-Intuition.html
+++ b/Trust-Your-Intuition.html
@@ -11,7 +11,10 @@
 <body>
     <header>
         <div class="header-content">
-            <a href="index.html" class="logo">Seen and Red</a>
+            <div>
+                <a href="index.html" class="logo">Seen and Red</a>
+                <p class="site-tagline">Your AI Bestie with a PhD</p>
+            </div>
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>
@@ -170,11 +173,23 @@
 
                     <p><strong>That pit in your stomach? It's not paranoia. It's protection. Listen to it.</strong></p>
 
-                    <div class="cta-section">
-                        <h3>Ready to Trust Your Gut?</h3>
-                        <p>Get unlimited message analysis to learn the difference between intuition and anxiety.</p>
-                        <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="cta-button" target="_blank" rel="nofollow noopener">Unlock Unlimited Analysis – $12/mo</a>
-                    </div>
+                    <section class="cta-upsell" role="region" aria-labelledby="cta-upsell-heading">
+                        <p id="cta-upsell-heading" class="cta-upsell__heading">Want Clarity on Your Own Messages?</p>
+                        <p class="cta-upsell__subcopy">
+                            Get unlimited message analysis for just $12/month — plus a free subscription to the Seen &amp; Red Dispatch with insider tips, real dating stories, and red-flag breakdowns.
+                        </p>
+
+                        <a
+                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            class="cta-upsell__button"
+                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            rel="nofollow noopener"
+                        >
+                            Unlock Unlimited Analysis — $12/mo
+                        </a>
+
+                        <p class="cta-upsell__perk">Includes our weekly Seen &amp; Red Dispatch newsletter. Unsubscribe anytime.</p>
+                    </section>
                 </div>
             </div>
         </article>

--- a/blog.html
+++ b/blog.html
@@ -12,7 +12,10 @@
     <header>
         <div class="container">
             <div class="header-content">
-                <a href="index.html" class="logo">Seen and Red</a>
+                <div>
+                    <a href="index.html" class="logo">Seen and Red</a>
+                    <p class="site-tagline">Your AI Bestie with a PhD</p>
+                </div>
                 <nav>
                     <ul>
                         <li><a href="index.html">Home</a></li>
@@ -64,11 +67,23 @@
                         <p>Discover how a group of women uncovered overlapping dating experiences.</p>
                     </article>
                 </div>
-                <div class="cta-section">
-                    <h2>Want Clarity on Your Own Messages?</h2>
-                    <p>Get unlimited message analysis for just $12/month.</p>
-                    <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="cta-button" target="_blank" rel="nofollow noopener">Unlock Unlimited Analysis – $12/mo</a>
-                </div>
+                <section class="cta-upsell" role="region" aria-labelledby="cta-upsell-heading">
+                    <p id="cta-upsell-heading" class="cta-upsell__heading">Want Clarity on Your Own Messages?</p>
+                    <p class="cta-upsell__subcopy">
+                        Get unlimited message analysis for just $12/month — plus a free subscription to the Seen &amp; Red Dispatch with insider tips, real dating stories, and red-flag breakdowns.
+                    </p>
+
+                    <a
+                        href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                        class="cta-upsell__button"
+                        aria-label="Unlock Unlimited Analysis for $12 per month"
+                        rel="nofollow noopener"
+                    >
+                        Unlock Unlimited Analysis — $12/mo
+                    </a>
+
+                    <p class="cta-upsell__perk">Includes our weekly Seen &amp; Red Dispatch newsletter. Unsubscribe anytime.</p>
+                </section>
             </div>
         </section>
     </main>

--- a/contact.html
+++ b/contact.html
@@ -287,12 +287,29 @@
                 padding: 0 15px;
             }
         }
+
+        .site-tagline {
+            display: block !important;
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: var(--dark-gray, #1f2937);
+            text-align: center;
+            margin-top: 6px;
+            line-height: 1.3;
+        }
+
+        @media (min-width: 768px) {
+            .site-tagline { font-size: 1rem; }
+        }
     </style>
 </head>
 <body>
     <header>
         <div class="header-content">
-            <a href="index.html" class="logo">Seen and Red</a>
+            <div>
+                <a href="index.html" class="logo">Seen and Red</a>
+                <p class="site-tagline">Your AI Bestie with a PhD</p>
+            </div>
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>

--- a/ignoring-red-flags.html
+++ b/ignoring-red-flags.html
@@ -11,7 +11,10 @@
 <body>
     <header>
         <div class="header-content">
-            <a href="index.html" class="logo">Seen and Red</a>
+            <div>
+                <a href="index.html" class="logo">Seen and Red</a>
+                <p class="site-tagline">Your AI Bestie with a PhD</p>
+            </div>
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>
@@ -150,11 +153,23 @@
 
                     <p>It starts with recognizing that <strong>you are worthy of love that feels safe, consistent, and peaceful.</strong> Your inner child might resist this truth, but your adult self deserves to heal.</p>
 
-                    <div class="cta-section">
-                        <h3>Ready to Break Free?</h3>
-                        <p>Get personalized breakdowns of your messages and spot manipulation tactics before you get trapped.</p>
-                        <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="cta-button" target="_blank" rel="nofollow noopener">Unlock Unlimited Analysis – $12/mo</a>
-                    </div>
+                    <section class="cta-upsell" role="region" aria-labelledby="cta-upsell-heading">
+                        <p id="cta-upsell-heading" class="cta-upsell__heading">Want Clarity on Your Own Messages?</p>
+                        <p class="cta-upsell__subcopy">
+                            Get unlimited message analysis for just $12/month — plus a free subscription to the Seen &amp; Red Dispatch with insider tips, real dating stories, and red-flag breakdowns.
+                        </p>
+
+                        <a
+                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            class="cta-upsell__button"
+                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            rel="nofollow noopener"
+                        >
+                            Unlock Unlimited Analysis — $12/mo
+                        </a>
+
+                        <p class="cta-upsell__perk">Includes our weekly Seen &amp; Red Dispatch newsletter. Unsubscribe anytime.</p>
+                    </section>
                 </div>
             </div>
         </article>

--- a/index.html
+++ b/index.html
@@ -635,13 +635,87 @@
         @media (min-width: 768px){
           #hero-cta.hero-ctas{ align-items:flex-start; gap:18px; }
         }
+        /* ===== CTA Upsell ===== */
+        .cta-upsell {
+          background-color: var(--light-red, #fee2e2);
+          border-radius: 12px;
+          padding: 18px;
+          margin: 24px auto;
+          text-align: center;
+          max-width: 720px;
+        }
+
+        .cta-upsell__heading {
+          font-size: 1.25rem;
+          font-weight: 800;
+          margin-bottom: 8px;
+          color: var(--dark-gray, #1f2937);
+        }
+
+        .cta-upsell__subcopy {
+          font-size: 1rem;
+          line-height: 1.5;
+          color: var(--dark-gray, #1f2937);
+          margin: 0 auto 14px;
+          max-width: 42ch;
+        }
+
+        .cta-upsell__button {
+          display: inline-block;
+          padding: 12px 20px;
+          border-radius: 8px;
+          background-color: var(--primary-red, #dc2626);
+          color: #fff;
+          font-weight: 700;
+          text-decoration: none;
+          font-size: 1rem;
+          line-height: 1;
+          transition: transform 0.05s ease, background-color 0.15s ease;
+          box-shadow: 0 2px 0 var(--dark-red, #991b1b);
+        }
+
+        .cta-upsell__button:hover,
+        .cta-upsell__button:focus {
+          background-color: var(--dark-red, #991b1b);
+        }
+
+        .cta-upsell__button:active {
+          transform: translateY(1px);
+        }
+
+        .cta-upsell__perk {
+          margin-top: 10px;
+          font-size: 0.9rem;
+          color: var(--dark-gray, #1f2937);
+          opacity: 0.9;
+        }
+
+        /* ===== Tagline visibility & sizing ===== */
+        .site-tagline {
+          display: block !important;
+          font-size: 0.95rem;
+          font-weight: 500;
+          color: var(--dark-gray, #1f2937);
+          text-align: center;
+          margin-top: 6px;
+          line-height: 1.3;
+        }
+
+        @media (min-width: 768px) {
+          .cta-upsell { padding: 22px 28px; }
+          .cta-upsell__heading { font-size: 1.35rem; }
+          .site-tagline { font-size: 1rem; }
+        }
     </style>
 </head>
 <body>
     <header>
         <div class="container">
             <div class="header-content">
-                <a href="#home" class="logo">Seen and Red</a>
+                <div>
+                    <a href="#home" class="logo">Seen and Red</a>
+                    <p class="site-tagline">Your AI Bestie with a PhD</p>
+                </div>
 <nav class="main-nav">
   <ul>
     <li><a href="#home">Home</a></li>

--- a/missing-green-flags.html
+++ b/missing-green-flags.html
@@ -11,7 +11,10 @@
 <body>
     <header>
         <div class="header-content">
-            <a href="index.html" class="logo">Seen and Red</a>
+            <div>
+                <a href="index.html" class="logo">Seen and Red</a>
+                <p class="site-tagline">Your AI Bestie with a PhD</p>
+            </div>
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>
@@ -117,11 +120,23 @@
 
                     <p>Start paying attention. The right person might already be showing you who they are—you just might need to learn how to see it.</p>
 
-                    <div class="cta-section">
-                        <h3>Ready to Break the Pattern?</h3>
-                        <p>Get unlimited message analysis and learn to spot both red and green flags in your actual conversations.</p>
-                        <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="cta-button" target="_blank" rel="nofollow noopener">Unlock Unlimited Analysis – $12/mo</a>
-                    </div>
+                    <section class="cta-upsell" role="region" aria-labelledby="cta-upsell-heading">
+                        <p id="cta-upsell-heading" class="cta-upsell__heading">Want Clarity on Your Own Messages?</p>
+                        <p class="cta-upsell__subcopy">
+                            Get unlimited message analysis for just $12/month — plus a free subscription to the Seen &amp; Red Dispatch with insider tips, real dating stories, and red-flag breakdowns.
+                        </p>
+
+                        <a
+                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            class="cta-upsell__button"
+                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            rel="nofollow noopener"
+                        >
+                            Unlock Unlimited Analysis — $12/mo
+                        </a>
+
+                        <p class="cta-upsell__perk">Includes our weekly Seen &amp; Red Dispatch newsletter. Unsubscribe anytime.</p>
+                    </section>
                 </div>
             </div>
         </article>

--- a/styles.css
+++ b/styles.css
@@ -36,3 +36,75 @@ nav ul {
   max-width: 100%;
   height: auto;
 }
+
+/* ===== CTA Upsell ===== */
+.cta-upsell {
+  background-color: var(--light-red, #fee2e2);
+  border-radius: 12px;
+  padding: 18px;
+  margin: 24px auto;
+  text-align: center;
+  max-width: 720px;
+}
+
+.cta-upsell__heading {
+  font-size: 1.25rem;
+  font-weight: 800;
+  margin-bottom: 8px;
+  color: var(--dark-gray, #1f2937);
+}
+
+.cta-upsell__subcopy {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--dark-gray, #1f2937);
+  margin: 0 auto 14px;
+  max-width: 42ch;
+}
+
+.cta-upsell__button {
+  display: inline-block;
+  padding: 12px 20px;
+  border-radius: 8px;
+  background-color: var(--primary-red, #dc2626);
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform 0.05s ease, background-color 0.15s ease;
+  box-shadow: 0 2px 0 var(--dark-red, #991b1b);
+}
+
+.cta-upsell__button:hover,
+.cta-upsell__button:focus {
+  background-color: var(--dark-red, #991b1b);
+}
+
+.cta-upsell__button:active {
+  transform: translateY(1px);
+}
+
+.cta-upsell__perk {
+  margin-top: 10px;
+  font-size: 0.9rem;
+  color: var(--dark-gray, #1f2937);
+  opacity: 0.9;
+}
+
+/* ===== Tagline visibility & sizing ===== */
+.site-tagline {
+  display: block !important;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--dark-gray, #1f2937);
+  text-align: center;
+  margin-top: 6px;
+  line-height: 1.3;
+}
+
+@media (min-width: 768px) {
+  .cta-upsell { padding: 22px 28px; }
+  .cta-upsell__heading { font-size: 1.35rem; }
+  .site-tagline { font-size: 1rem; }
+}

--- a/terms.html
+++ b/terms.html
@@ -205,12 +205,29 @@
                 padding: 0 15px;
             }
         }
+
+        .site-tagline {
+            display: block !important;
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: var(--dark-gray, #1f2937);
+            text-align: center;
+            margin-top: 6px;
+            line-height: 1.3;
+        }
+
+        @media (min-width: 768px) {
+            .site-tagline { font-size: 1rem; }
+        }
     </style>
 </head>
 <body>
     <header>
         <div class="header-content">
-            <a href="index.html" class="logo">Seen and Red</a>
+            <div>
+                <a href="index.html" class="logo">Seen and Red</a>
+                <p class="site-tagline">Your AI Bestie with a PhD</p>
+            </div>
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>


### PR DESCRIPTION
## Summary
- Replace plain upsell links with an accessible CTA component that includes Seen & Red Dispatch newsletter info
- Surface site tagline "Your AI Bestie with a PhD" under the logo and ensure it's visible on mobile
- Add shared styles for CTA and tagline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f54488c9c8326ad740679587cb306