### PR TITLE
Anchor Unlimited signup form and update CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -728,7 +728,7 @@
         Free Analysis
       </a>
     </li>
-    <li><a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="nav-link" target="_blank" rel="nofollow noopener" aria-label="Go Unlimited — Reality Check: unlimited decodes, juicier insights, cancel anytime">Go Unlimited — Reality Check</a></li>
+    <li><a href="#unlimited-form" class="nav-link" aria-label="Go Unlimited — Reality Check: unlimited decodes, juicier insights, cancel anytime">Go Unlimited — Reality Check</a></li>
   </ul>
 </nav>
 
@@ -747,7 +747,7 @@
                         <div class="cta-subtext">Quick, no-strings insight on one message</div>
                     </div>
                     <div class="cta-block cta-block--unlimited">
-                        <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="btn btn--unlimited" aria-label="Go Unlimited — Reality Check">Go Unlimited — Reality Check</a>
+                        <a href="#unlimited-form" class="btn btn--unlimited" aria-label="Go Unlimited — Reality Check">Go Unlimited — Reality Check</a>
                         <div class="cta-subtext">Ongoing deep dives to decode the whole story</div>
                     </div>
                 </div>
@@ -761,21 +761,23 @@
                     Tired of asking your friends "but what do you think this means?" Let's get some actual answers, bestie.
                 </p>
                 <div class="pricing-grid">
-                    <div class="pricing-card featured">
-                        <div class="featured-badge">Best Value</div>
-                        <div class="pricing-header">
-                            <h3>Unlimited Analysis</h3>
-                            <div class="price">$12</div>
-                            <p class="price-period">Per month</p>
+                    <div id="unlimited-form">
+                        <div class="pricing-card featured">
+                            <div class="featured-badge">Best Value</div>
+                            <div class="pricing-header">
+                                <h3>Unlimited Analysis</h3>
+                                <div class="price">$12</div>
+                                <p class="price-period">Per month</p>
+                            </div>
+                            <ul class="pricing-features">
+                                <li>Unlimited Message Analysis (go wild, bestie)</li>
+                                <li>Deep Pattern Recognition & Trauma Insights</li>
+                                <li>24/7 Access to Your AI Truth-Teller</li>
+                                <li>Priority Support</li>
+                                <li>Cancel Anytime (but you won't want to)</li>
+                            </ul>
+                            <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="pricing-button" target="_blank" rel="nofollow noopener">Get Unlimited Analysis</a>
                         </div>
-                        <ul class="pricing-features">
-                            <li>Unlimited Message Analysis (go wild, bestie)</li>
-                            <li>Deep Pattern Recognition & Trauma Insights</li>
-                            <li>24/7 Access to Your AI Truth-Teller</li>
-                            <li>Priority Support</li>
-                            <li>Cancel Anytime (but you won't want to)</li>
-                        </ul>
-                        <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="pricing-button" target="_blank" rel="nofollow noopener">Get Unlimited Analysis</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Wrap Unlimited pricing card with `#unlimited-form` for in-page navigation
- Point Unlimited navigation and hero CTA buttons to `#unlimited-form`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f85d443b08326b28dface21b325f0