### PR TITLE
Point CTA buttons to onsite Unlimited Analysis form

### DIFF
--- a/Healing-Your-Patterns.html
+++ b/Healing-Your-Patterns.html
@@ -68,9 +68,9 @@
                         </p>
 
                         <a
-                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            href="#unlimited-form"
                             class="cta-upsell__button"
-                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
                         >
                             Unlock Unlimited Analysis — $12/mo

--- a/Trust-Your-Intuition.html
+++ b/Trust-Your-Intuition.html
@@ -180,9 +180,9 @@
                         </p>
 
                         <a
-                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            href="#unlimited-form"
                             class="cta-upsell__button"
-                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
                         >
                             Unlock Unlimited Analysis — $12/mo

--- a/blog.html
+++ b/blog.html
@@ -74,9 +74,9 @@
                     </p>
 
                     <a
-                        href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                        href="#unlimited-form"
                         class="cta-upsell__button"
-                        aria-label="Unlock Unlimited Analysis for $12 per month"
+                        aria-label="Go to Unlimited Analysis form"
                         rel="nofollow noopener"
                     >
                         Unlock Unlimited Analysis — $12/mo

--- a/ignoring-red-flags.html
+++ b/ignoring-red-flags.html
@@ -160,9 +160,9 @@
                         </p>
 
                         <a
-                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            href="#unlimited-form"
                             class="cta-upsell__button"
-                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
                         >
                             Unlock Unlimited Analysis — $12/mo

--- a/missing-green-flags.html
+++ b/missing-green-flags.html
@@ -127,9 +127,9 @@
                         </p>
 
                         <a
-                            href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00?utm_source=site&amp;utm_medium=cta&amp;utm_campaign=homepage_upsell"
+                            href="#unlimited-form"
                             class="cta-upsell__button"
-                            aria-label="Unlock Unlimited Analysis for $12 per month"
+                            aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
                         >
                             Unlock Unlimited Analysis — $12/mo


### PR DESCRIPTION
## Summary
- Redirect CTA buttons on blog and article pages to the internal `#unlimited-form` section
- Add accessibility label "Go to Unlimited Analysis form" for these CTAs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f85d399c48326bca9d40f363bc035