### PR TITLE
Update decode CTAs to Jotform

### DIFF
--- a/are-we-dating-the-same-guy.html
+++ b/are-we-dating-the-same-guy.html
@@ -30,7 +30,7 @@
         <div class="cta-section">
             <h3>Need a Flag Check?</h3>
             <p>Send in your screenshots and get a trauma-informed breakdown before the next date.</p>
-            <a href="/decode.html?tier=flag">Submit a Flag Check</a>
+            <a href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Submit a Flag Check</a>
         </div>
     </main>
     <footer>

--- a/blog/dating-in-the-era-of-social-media.html
+++ b/blog/dating-in-the-era-of-social-media.html
@@ -137,9 +137,15 @@
 
     <hr>
     <h2>Keep Going (and Get Backup)</h2>
-    <p><strong>Free Clarity Quiz:</strong> Spot patterns fast. → <a href="/blog/">/blog</a></p>
-    <p><strong>Message Decode:</strong> Paste a DM or text and get a flag check in minutes. → <a href="/decode.html">/decode.html</a></p>
-    <p><em>Need receipts on a weird DM? Drop it into the Decode tool—Red will translate the subtext with compassion and science.</em></p>
+    <p>
+      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener" aria-label="Get a free message analysis">Free Message Analysis</a>
+      <a class="sr-btn" href="/#quiz" aria-label="Take the Free Clarity Quiz">Free Clarity Quiz</a>
+    </p>
+    <p><strong>Prefer links?</strong>
+      <a href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Decode a Message (free)</a> •
+      <a href="/#quiz">Free Clarity Quiz</a>
+    </p>
+    <p><em>Need receipts on a weird DM? Drop it into the <a href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Decode form</a>—Red will translate the subtext with compassion and science.</em></p>
   </main>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -582,10 +582,7 @@
     <li><a href="blog.html">Blog</a></li>
     <li><a href="about.html">About</a></li>
     <li>
-      <a href="https://form.jotform.com/252205735289057"
-         class="nav-link" target="_blank" rel="noopener">
-        Free Analysis
-      </a>
+      <a href="https://form.jotform.com/252205735289057" class="nav-link" target="_blank" rel="noopener">Decode</a>
     </li>
     <li><a href="#unlimited-form" class="nav-link" aria-label="Go Unlimited — Reality Check: unlimited decodes, juicier insights, cancel anytime">Go Unlimited — Reality Check</a></li>
   </ul>
@@ -602,7 +599,7 @@
     <h1 class="sr-hero-title">Seen &amp; Red</h1>
     <p class="sr-hero-sub">Research-backed clarity for modern dating.</p>
     <p>
-      <a class="sr-btn" href="/decode.html">Decode a Message</a>
+      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener" aria-label="Decode a Message (free analysis)">Decode a Message</a>
       <a class="sr-btn" href="/blog/">Read the Blog</a>
     </p>
   </div>


### PR DESCRIPTION
## Summary
- Point homepage hero "Decode a Message" button to Jotform and open in a new tab.
- Replace "Keep Going" section in social-media dating article with buttons and links for Jotform and the quiz.
- Ensure all flag-check CTAs, including Clarity Diaries post, use the Jotform URL.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6445dc1e08326857ad6a914735063