### PR TITLE
Revamp blog index layout with new posts and CTA

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -12,23 +12,24 @@
   <style id="sr-blog-inline">
 :root{--sr-red:#C8102E;--sr-red-soft:#E63946;--sr-ink:#1A1A1A;--sr-muted:#666;--sr-border:#EDEDED;--sr-card:#fff;--sr-radius:16px;--sr-shadow:0 6px 20px rgba(0,0,0,.08)}
 html,body{margin:0}
-.sr-container{max-width:1100px;margin:0 auto;padding:28px 18px 80px}
+.sr-container{max-width:1200px;margin:0 auto;padding:28px 18px 80px}
 .sr-page-title{font-family:"Playfair Display",Georgia,serif;font-size:clamp(28px,5vw,40px);margin:8px 0 10px}
 .sr-page-sub{font-family:"Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans",sans-serif;color:var(--sr-muted);margin:0 0 20px}
-.post-grid{display:grid;grid-template-columns:1fr;gap:18px}
-@media(min-width:720px){.post-grid{grid-template-columns:1fr 1fr}}
+.post-grid{display:grid;gap:18px;grid-template-columns:1fr}
+@media(min-width:700px){.post-grid{grid-template-columns:1fr 1fr}}
+@media(min-width:1000px){.post-grid{grid-template-columns:1fr 1fr 1fr}}
 .post-card{background:var(--sr-card);border:1px solid var(--sr-border);border-radius:var(--sr-radius);overflow:hidden;box-shadow:var(--sr-shadow);transition:transform .12s,box-shadow .12s}
 .post-card:hover{transform:translateY(-3px);box-shadow:0 10px 30px rgba(0,0,0,.12)}
-.post-link{display:grid;grid-template-rows:auto 1fr;text-decoration:none;color:inherit}
+.post-link{display:grid;grid-template-rows:auto 1fr;text-decoration:none;color:inherit;height:100%}
 .post-thumb{aspect-ratio:16/9;width:100%;object-fit:cover;display:block}
-.post-thumb.placeholder{background:linear-gradient(135deg,#fff 0%,#fdecef 100%);display:grid;place-items:center;font-family:"Playfair Display",Georgia,serif;font-size:22px;color:var(--sr-red)}
-.post-body{padding:16px 16px 18px}
-.post-title{font-family:"Playfair Display",Georgia,serif;font-size:clamp(20px,2.4vw,24px);margin:0 0 6px;color:var(--sr-ink)}
-.post-meta{font-family:"Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans",sans-serif;color:var(--sr-muted);font-size:.92rem;margin:0 0 8px}
-.post-excerpt{font-family:"Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans",sans-serif;margin:0;opacity:.95}
-.sr-cta{margin-top:28px;padding:16px;border:1px solid var(--sr-border);border-radius:var(--sr-radius);background:#fff;box-shadow:var(--sr-shadow);display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:space-between}
+.post-thumb.placeholder{background:linear-gradient(135deg,#fff 0%,#fdecef 100%);display:grid;place-items:center;font-family:"Playfair Display",Georgia,serif;font-size:18px;color:var(--sr-red)}
+.post-body{padding:14px 14px 16px}
+.post-title{font-family:"Playfair Display",Georgia,serif;font-size:clamp(18px,2.1vw,22px);margin:0 0 6px;color:var(--sr-ink)}
+.post-meta{font-family:"Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans",sans-serif;color:var(--sr-muted);font-size:.9rem;margin:0 0 8px}
+.post-excerpt{font-family:"Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans",sans-serif;margin:0;opacity:.95;font-size:.98rem}
+.sr-cta{margin-top:22px;padding:14px;border:1px solid var(--sr-border);border-radius:var(--sr-radius);background:#fff;box-shadow:var(--sr-shadow);display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:space-between}
 .sr-cta-text{font-family:"Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans",sans-serif;margin:0 8px 0 0;color:var(--sr-ink)}
-.sr-btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:600;transition:transform .08s,background .2s}
+.sr-btn{display:inline-block;background:var(--sr-red);color:#fff;padding:10px 14px;border-radius:999px;text-decoration:none;font-weight:700;font-size:.95rem;transition:transform .08s,background .2s}
 .sr-btn:hover{background:var(--sr-red-soft);transform:translateY(-1px)}
 /* Build badge */
 #sr-build-badge{position:fixed;right:12px;bottom:12px;z-index:9999;background:#1A1A1A;color:#fff;border-radius:999px;padding:8px 12px;font:600 12px/1 "Lato",system-ui}
@@ -40,44 +41,91 @@ html,body{margin:0}
   <p class="sr-page-sub">Research‑backed clarity for modern dating.</p>
 
   <section class="post-grid">
-    <!-- New article -->
+    <!-- Social Media article -->
     <article class="post-card">
-      <a class="post-link" href="/blog/dating-in-the-era-of-social-media.html?v=10" aria-label="Read: Dating in the Era of Social Media">
+      <a class="post-link" href="/blog/dating-in-the-era-of-social-media.html?v=13" aria-label="Read: Dating in the Era of Social Media">
+        <!-- Replace with <img class="post-thumb" src="/assets/img/posts/social-era.jpg" alt="…"> when you add a real image -->
         <div class="post-thumb placeholder">Seen &amp; Red</div>
         <div class="post-body">
           <h3 class="post-title">Dating in the Era of Social Media</h3>
           <p class="post-meta">Aug 20, 2025 · ~8 min read</p>
-          <p class="post-excerpt">Likes, DMs, &amp; group chats are rewriting the rules of love. Here’s how to set boundaries that actually work.</p>
+          <p class="post-excerpt">Likes, DMs, &amp; group chats are rewriting the rules of love. Set boundaries that actually work.</p>
         </div>
       </a>
     </article>
 
-    <!-- Are We Dating the Same Guy… Again? -->
+    <!-- Are We Dating the Same Guy… Again? (fixed slug) -->
     <article class="post-card">
       <a class="post-link" href="/blog/are-we-dating-the-same-guy-again.html" aria-label="Read: Are We Dating the Same Guy… Again?">
         <div class="post-thumb placeholder">Seen &amp; Red</div>
         <div class="post-body">
           <h3 class="post-title">Are We Dating the Same Guy… Again?</h3>
           <p class="post-meta">May 12, 2024 · ~6 min read</p>
-          <p class="post-excerpt">Facebook forums are changing how women date — and why receipts matter.</p>
+          <p class="post-excerpt">How Facebook forums reshape dating — and why receipts matter.</p>
         </div>
       </a>
     </article>
 
-    <!-- Add your other posts here exactly as above -->
+    <!-- Healing Your Patterns -->
+    <article class="post-card">
+      <a class="post-link" href="/blog/healing-your-patterns.html" aria-label="Read: Healing Your Patterns">
+        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <div class="post-body">
+          <h3 class="post-title">Healing Your Patterns: Breaking the Cycle</h3>
+          <p class="post-meta">Jun 15, 2024 · ~8 min read</p>
+          <p class="post-excerpt">Why we repeat relationship loops — and how to break them.</p>
+        </div>
+      </a>
+    </article>
+
+    <!-- Trust Your Intuition -->
+    <article class="post-card">
+      <a class="post-link" href="/blog/trust-your-intuition.html" aria-label="Read: Trust Your Intuition">
+        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <div class="post-body">
+          <h3 class="post-title">Trust Your Intuition</h3>
+          <p class="post-meta">Jul 10, 2024 · ~7 min read</p>
+          <p class="post-excerpt">When to trust your gut — and when it’s just anxiety talking.</p>
+        </div>
+      </a>
+    </article>
+
+    <!-- Missing Green Flags -->
+    <article class="post-card">
+      <a class="post-link" href="/blog/missing-green-flags.html" aria-label="Read: Missing Green Flags">
+        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <div class="post-body">
+          <h3 class="post-title">Missing Green Flags</h3>
+          <p class="post-meta">Jul 30, 2024 · ~5 min read</p>
+          <p class="post-excerpt">Spot when someone is actually showing up for you — even if it feels “too easy.”</p>
+        </div>
+      </a>
+    </article>
+
+    <!-- Ignoring Red Flags -->
+    <article class="post-card">
+      <a class="post-link" href="/blog/ignoring-red-flags.html" aria-label="Read: Ignoring Red Flags">
+        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <div class="post-body">
+          <h3 class="post-title">Ignoring Red Flags</h3>
+          <p class="post-meta">Aug 8, 2024 · ~6 min read</p>
+          <p class="post-excerpt">How past wounds can make manipulation feel like love.</p>
+        </div>
+      </a>
+    </article>
   </section>
 
   <!-- CTA row -->
   <div class="sr-cta">
-    <p class="sr-cta-text"><strong>Want clarity on your own messages?</strong> Get a free analysis or take the quiz.</p>
+    <p class="sr-cta-text"><strong>Want clarity on your own messages?</strong></p>
     <div>
-      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Decode a Message (free)</a>
-      <a class="sr-btn" href="/#quiz">Free Clarity Quiz</a>
+      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+      <a class="sr-btn" href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
     </div>
   </div>
 </div>
 
-<div id="sr-build-badge">Seen &amp; Red • Blog Build v10</div>
+<div id="sr-build-badge">Seen &amp; Red • Blog Build v13</div>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Upgrade blog index styling with 3-column responsive grid and refined card design
- Populate index with six article cards and update build badge to v13
- Replace Decode CTA with Analyze and add upsell link for Unlimited Analysis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74b5987988326acfa89abefb27215