### PR TITLE
Update upsell links to Stripe and rename navigation label

### DIFF
--- a/Healing-Your-Patterns.html
+++ b/Healing-Your-Patterns.html
@@ -71,10 +71,11 @@
                         </p>
 
                         <a
-                            href="#unlimited-form"
+                            href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
                             class="cta-upsell__button"
                             aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
+                            target="_blank"
                         >
                             Unlock Unlimited Analysis — $12/mo
                         </a>

--- a/Trust-Your-Intuition.html
+++ b/Trust-Your-Intuition.html
@@ -183,10 +183,11 @@
                         </p>
 
                         <a
-                            href="#unlimited-form"
+                            href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
                             class="cta-upsell__button"
                             aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
+                            target="_blank"
                         >
                             Unlock Unlimited Analysis — $12/mo
                         </a>

--- a/blog.html
+++ b/blog.html
@@ -47,7 +47,7 @@ html,body{margin:0}
                 <nav>
                     <ul>
                         <li><a href="index.html">Home</a></li>
-                        <li><a href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Decode</a></li>
+                        <li><a href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="about.html">About</a></li>
                     </ul>

--- a/blog/index.html
+++ b/blog/index.html
@@ -120,7 +120,7 @@ html,body{margin:0}
     <p class="sr-cta-text"><strong>Want clarity on your own messages?</strong></p>
     <div>
       <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-      <a class="sr-btn" href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+      <a class="sr-btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
     </div>
   </div>
 </div>

--- a/config/site.json
+++ b/config/site.json
@@ -1,3 +1,3 @@
 {
-  "STRIPE_UNLIMITED_URL": "https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00"
+  "STRIPE_UNLIMITED_URL": "https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
 }

--- a/ignoring-red-flags.html
+++ b/ignoring-red-flags.html
@@ -163,10 +163,11 @@
                         </p>
 
                         <a
-                            href="#unlimited-form"
+                            href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
                             class="cta-upsell__button"
                             aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
+                            target="_blank"
                         >
                             Unlock Unlimited Analysis — $12/mo
                         </a>

--- a/index.html
+++ b/index.html
@@ -582,9 +582,9 @@
     <li><a href="blog.html">Blog</a></li>
     <li><a href="about.html">About</a></li>
     <li>
-      <a href="https://form.jotform.com/252205735289057" class="nav-link" target="_blank" rel="noopener">Decode</a>
+      <a href="https://form.jotform.com/252205735289057" class="nav-link" target="_blank" rel="noopener">Analyze</a>
     </li>
-    <li><a href="#unlimited-form" class="nav-link" aria-label="Go Unlimited — Reality Check: unlimited decodes, juicier insights, cancel anytime">Go Unlimited — Reality Check</a></li>
+    <li><a href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" class="nav-link" aria-label="Go Unlimited — Reality Check: unlimited decodes, juicier insights, cancel anytime" target="_blank" rel="noopener">Go Unlimited — Reality Check</a></li>
   </ul>
 </nav>
 
@@ -626,7 +626,7 @@
                                 <li>Priority Support</li>
                                 <li>Cancel Anytime (but you won't want to)</li>
                             </ul>
-                            <a href="https://buy.stripe.com/3cIbJ3bpJedZ6uI82He3e00" class="pricing-button" target="_blank" rel="nofollow noopener">Get Unlimited Analysis</a>
+                            <a href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" class="pricing-button" target="_blank" rel="nofollow noopener">Get Unlimited Analysis</a>
                         </div>
                     </div>
                 </div>

--- a/missing-green-flags.html
+++ b/missing-green-flags.html
@@ -130,10 +130,11 @@
                         </p>
 
                         <a
-                            href="#unlimited-form"
+                            href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
                             class="cta-upsell__button"
                             aria-label="Go to Unlimited Analysis form"
                             rel="nofollow noopener"
+                            target="_blank"
                         >
                             Unlock Unlimited Analysis — $12/mo
                         </a>


### PR DESCRIPTION
## Summary
- Point Unlimited Analysis buttons to Stripe checkout
- Rename navigation "Decode" link to "Analyze" pointing to Jotform
- Update site config with new Stripe URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74f2c23ec832684cd6a70a90e3a78