### PR TITLE
Add missing blog article pages

### DIFF
--- a/blog/healing-your-patterns.html
+++ b/blog/healing-your-patterns.html
@@ -1,0 +1,65 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Healing Your Patterns: Breaking the Cycle | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Why we repeat relationship patterns and how to retrain your nervous system, boundaries, and choices so healthy love feels familiar.">
+<link rel="canonical" href="https://seenandred.com/blog/healing-your-patterns.html">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-red:#C8102E;--sr-red-soft:#E63946;--sr-ink:#1A1A1A;--sr-muted:#666;--sr-border:#EDEDED}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.65}
+a{color:var(--sr-red);text-underline-offset:3px}a:hover{color:var(--sr-red-soft)}
+main.sr-article{max-width:760px;margin:0 auto;padding:28px 20px 90px}
+h1,h2,h3{font-family:"Playfair Display",Georgia,serif;line-height:1.25}
+h1{font-size:clamp(30px,4.5vw,44px);margin:.35rem 0 .6rem}
+.meta{color:var(--sr-muted);font-size:.94rem;margin-bottom:1rem}
+hr{border:0;border-top:1px solid var(--sr-border);margin:26px 0}
+blockquote{border-left:3px solid var(--sr-red-soft);background:#FFF6F7;margin:18px 0;padding:14px 16px;border-radius:8px;font-style:italic}
+ul,ol{margin:10px 0 16px 20px}
+.btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{background:var(--sr-red-soft)}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
+</style>
+<meta property="og:title" content="Healing Your Patterns: Breaking the Cycle">
+<meta property="og:description" content="A practical framework for changing repeated relationship choices.">
+<meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/healing-your-patterns.html">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Healing Your Patterns: Breaking the Cycle","datePublished":"2024-06-15","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"A practical framework for changing repeated relationship choices."}</script>
+</head><body>
+<main class="sr-article">
+<h1>Healing Your Patterns: Breaking the Cycle</h1>
+<p class="meta">Published: June 15, 2024 • ~8 min read</p>
+
+<p>We don’t only date with logic—we date with our nervous system. Old dynamics can feel “chemically right,” even when they’re unhealthy. Here’s how to break the loop without shaming yourself.</p>
+
+<hr><h2>The Pattern Triangle</h2>
+<ol>
+<li><strong>Trigger.</strong> Loneliness, attraction, or anxiety.</li>
+<li><strong>Story.</strong> “If I try harder, I’ll be chosen.”</li>
+<li><strong>Behaviour.</strong> Over‑investing, ignoring red flags, shrinking needs.</li>
+</ol>
+
+<h2>Reset in Three Lanes</h2>
+<ul>
+<li><strong>Body:</strong> Regulate (box breathing, cold splash, short walk) before you text.</li>
+<li><strong>Boundary:</strong> One‑line standard (e.g., “I don’t chase; I invite.”).</li>
+<li><strong>Behaviour:</strong> Replace a pursuit move with a clarity move (ask, then pause).</li>
+</ul>
+
+<h2>Five Replacement Habits</h2>
+<ul>
+<li>48‑hour rule before escalating intimacy.</li>
+<li>Two‑text maximum if they’re inconsistent; then step back.</li>
+<li>Sunday review: three green flags you saw this week.</li>
+<li>Save the story, judge the pattern.</li>
+<li>Choose boring‑safe over thrilling‑chaotic for 90 days.</li>
+</ul>
+
+<hr>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+</main>
+<div id="sr-build">Build: patterns</div>
+</body></html>

--- a/blog/ignoring-red-flags.html
+++ b/blog/ignoring-red-flags.html
@@ -1,0 +1,61 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Ignoring Red Flags | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Why past wounds can make manipulation feel like love—and how to move from excuses to clear standards.">
+<link rel="canonical" href="https://seenandred.com/blog/ignoring-red-flags.html">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-red:#C8102E;--sr-red-soft:#E63946;--sr-ink:#1A1A1A;--sr-muted:#666;--sr-border:#EDEDED}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.65}
+a{color:var(--sr-red)}a:hover{color:var(--sr-red-soft)}
+main.sr-article{max-width:760px;margin:0 auto;padding:28px 20px 90px}
+h1,h2,h3{font-family:"Playfair Display",Georgia,serif;line-height:1.25}
+.meta{color:var(--sr-muted);font-size:.94rem;margin-bottom:1rem}
+hr{border:0;border-top:1px solid var(--sr-border);margin:26px 0}
+ul,ol{margin:10px 0 16px 20px}
+.btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{background:var(--sr-red-soft)}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
+</style>
+<meta property="og:title" content="Ignoring Red Flags">
+<meta property="og:description" content="From excuses to standards—spot patterns early and act sooner.">
+<meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/ignoring-red-flags.html">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Ignoring Red Flags","datePublished":"2024-08-08","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"From excuses to standards—spot patterns early and act sooner."}</script>
+</head><body>
+<main class="sr-article">
+<h1>Ignoring Red Flags</h1>
+<p class="meta">Published: August 8, 2024 • ~6 min read</p>
+
+<p>Red flags don’t vanish; they compound. Here’s a quick rubric to spot, test, and decide without self‑gaslighting.</p>
+
+<h2>Common Red Flags</h2>
+<ul>
+<li>Hot–cold attention, especially after intimacy.</li>
+<li>Secretive phone habits + defensiveness when asked.</li>
+<li>Words of commitment; actions of casual.</li>
+</ul>
+
+<h2>Test the Behaviour</h2>
+<ol>
+<li>State a boundary (“I don’t continue when communication drops”).</li>
+<li>Offer one chance to repair with a clear request.</li>
+<li>If repeated—end contact kindly and completely.</li>
+</ol>
+
+<h2>Self‑Protection</h2>
+<ul>
+<li>Tell a friend your plan; ask them to mirror you.</li>
+<li>Block instead of monitoring.</li>
+<li>Journal what you did right, not just what hurt.</li>
+</ul>
+
+<hr>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+</main>
+<div id="sr-build">Build: red-flags</div>
+</body></html>

--- a/blog/missing-green-flags.html
+++ b/blog/missing-green-flags.html
@@ -1,0 +1,54 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Missing Green Flags | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="How to notice when someone is actually showing up—consistency, emotional safety, and reciprocity—so healthy doesn’t feel ‘boring.’">
+<link rel="canonical" href="https://seenandred.com/blog/missing-green-flags.html">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-red:#C8102E;--sr-red-soft:#E63946;--sr-ink:#1A1A1A;--sr-muted:#666;--sr-border:#EDEDED}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.65}
+a{color:var(--sr-red)}a:hover{color:var(--sr-red-soft)}
+main.sr-article{max-width:760px;margin:0 auto;padding:28px 20px 90px}
+h1,h2,h3{font-family:"Playfair Display",Georgia,serif;line-height:1.25}
+.meta{color:var(--sr-muted);font-size:.94rem;margin-bottom:1rem}
+hr{border:0;border-top:1px solid var(--sr-border);margin:26px 0}
+ul,ol{margin:10px 0 16px 20px}
+.btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{background:var(--sr-red-soft)}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
+</style>
+<meta property="og:title" content="Missing Green Flags">
+<meta property="og:description" content="A checklist for recognizing healthy effort and reciprocity.">
+<meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/missing-green-flags.html">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Missing Green Flags","datePublished":"2024-07-30","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"A checklist for recognizing healthy effort and reciprocity."}</script>
+</head><body>
+<main class="sr-article">
+<h1>Missing Green Flags</h1>
+<p class="meta">Published: July 30, 2024 • ~5 min read</p>
+
+<p>When chaos feels like chemistry, steady can feel “too easy.” Use this to recalibrate what healthy looks like.</p>
+
+<h2>The Big Three Greens</h2>
+<ul>
+<li><strong>Consistency:</strong> plans, follow‑through, repair after conflict.</li>
+<li><strong>Emotional safety:</strong> you can say no, ask questions, and feel heard.</li>
+<li><strong>Reciprocity:</strong> effort and care flow both directions.</li>
+</ul>
+
+<h2>Micro‑tests</h2>
+<ul>
+<li>Ask for a small change; see if it sticks.</li>
+<li>Share a boundary; watch for defensiveness vs. curiosity.</li>
+<li>Miss a text on purpose; do they spiral or stay steady?</li>
+</ul>
+
+<hr>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+</main>
+<div id="sr-build">Build: green-flags</div>
+</body></html>

--- a/blog/trust-your-intuition.html
+++ b/blog/trust-your-intuition.html
@@ -1,0 +1,62 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Trust Your Intuition | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="When to trust your gut in dating—and when anxiety or past hurt is impersonating intuition.">
+<link rel="canonical" href="https://seenandred.com/blog/trust-your-intuition.html">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-red:#C8102E;--sr-red-soft:#E63946;--sr-ink:#1A1A1A;--sr-muted:#666;--sr-border:#EDEDED}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.65}
+a{color:var(--sr-red)}a:hover{color:var(--sr-red-soft)}
+main.sr-article{max-width:760px;margin:0 auto;padding:28px 20px 90px}
+h1,h2,h3{font-family:"Playfair Display",Georgia,serif;line-height:1.25}
+h1{font-size:clamp(30px,4.5vw,44px)}
+.meta{color:var(--sr-muted);font-size:.94rem;margin-bottom:1rem}
+hr{border:0;border-top:1px solid var(--sr-border);margin:26px 0}
+ul,ol{margin:10px 0 16px 20px}
+.btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{background:var(--sr-red-soft)}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
+</style>
+<meta property="og:title" content="Trust Your Intuition">
+<meta property="og:description" content="A quick gut‑check framework to separate intuition from anxiety.">
+<meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/trust-your-intuition.html">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Trust Your Intuition","datePublished":"2024-07-10","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"A quick gut‑check framework to separate intuition from anxiety."}</script>
+</head><body>
+<main class="sr-article">
+<h1>Trust Your Intuition</h1>
+<p class="meta">Published: July 10, 2024 • ~7 min read</p>
+
+<p>Your gut can be wise—and it can also be wired by past pain. Use this 4‑part check to decide which voice you’re hearing.</p>
+
+<h2>Intuition vs. Anxiety</h2>
+<ul>
+<li><strong>Intuition:</strong> brief, clear, calm directive.</li>
+<li><strong>Anxiety:</strong> noisy, catastrophic, repetitive.</li>
+</ul>
+
+<h2>4‑Part Gut Check</h2>
+<ol>
+<li><strong>Body:</strong> Breathe, then scan—tight chest = slow down.</li>
+<li><strong>Data:</strong> What behaviours have you actually seen?</li>
+<li><strong>Dialogue:</strong> Ask one direct question; listen for consistency.</li>
+<li><strong>Decision:</strong> Make a small boundary, not a grand gesture.</li>
+</ol>
+
+<h2>Practice Reps</h2>
+<ul>
+<li>Say: “I like consistency. Can we pick a time that works weekly?”</li>
+<li>Pause texting when spiraling; move your body first.</li>
+<li>Journal one green flag per date; train your attention.</li>
+</ul>
+
+<hr>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+</main>
+<div id="sr-build">Build: intuition</div>
+</body></html>


### PR DESCRIPTION
## Summary
- add `healing-your-patterns`, `trust-your-intuition`, `missing-green-flags`, and `ignoring-red-flags` articles with on‑brand styling and CTAs
- ensure blog index cards link to the new slugs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c0aa5cd88326a4362572fe34a1cf