### PR TITLE
Add category landing pages with SEO schema

### DIFF
--- a/blog/dating-culture/index.html
+++ b/blog/dating-culture/index.html
@@ -1,0 +1,83 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Dating Culture — Social Media, Trends & Crowd Intel | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Social platforms and trends that shape modern dating — from Tea App to Facebook groups to soft launches.">
+<link rel="canonical" href="https://seenandred.com/blog/dating-culture/">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-coral:#FF6B6B;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.7}
+a{color:#ff4b4b;text-underline-offset:3px}
+main{max-width:980px;margin:0 auto;padding:28px 20px 96px}
+h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
+.hero{display:flex;flex-direction:column;gap:6px;margin:6px 0 12px}
+.kicker{display:inline-block;background:var(--sr-coral);color:#fff;border-radius:999px;padding:6px 10px;font:700 .78rem/1 Lato;text-transform:uppercase;letter-spacing:.02em}
+.grid{display:grid;gap:16px;margin-top:12px}
+@media(min-width:840px){.grid{grid-template-columns:1fr 1fr}}
+.card{border:1px solid var(--sr-border);border-radius:12px;overflow:hidden;background:#fff;display:flex;flex-direction:column}
+.card-body{padding:14px}
+.card h3{margin:.1rem 0 .25rem;font-size:1.15rem}
+.card p{margin:.25rem 0;color:var(--sr-muted)}
+.btn{display:inline-block;background:#ff4b4b;color:#fff;padding:10px 14px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{opacity:.9}
+.footer-cta{margin-top:24px}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato}
+</style>
+<meta property="og:title" content="Dating Culture — Social Media, Trends & Crowd Intel">
+<meta property="og:description" content="Social platforms and trends that shape modern dating.">
+<meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/dating-culture/">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{
+"@context":"https://schema.org",
+"@type":"CollectionPage",
+"name":"Dating Culture — Social Media, Trends & Crowd Intel",
+"description":"Social platforms and trends that shape modern dating.",
+"mainEntity":{
+  "@type":"ItemList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,
+     "url":"https://seenandred.com/blog/dating-in-the-era-of-social-media.html",
+     "name":"Dating in the Era of Social Media"},
+    {"@type":"ListItem","position":2,
+     "url":"https://seenandred.com/blog/crowdsourced-dating-safety-facebook-tea-app.html",
+     "name":"Crowdsourced Dating Safety (Facebook & Tea App)"}
+  ]
+}
+}
+</script>
+</head><body>
+<main>
+  <div class="hero">
+    <span class="kicker">Dating Culture</span>
+    <h1>Social Media & Crowd Intel: Using the Feed Without Losing Your Mind</h1>
+    <p>The scroll can be a safety net or a surveillance system. These guides help you set boundaries and use group intel wisely.</p>
+  </div>
+
+  <section class="grid" aria-label="Articles">
+    <article class="card">
+      <a href="/blog/dating-in-the-era-of-social-media.html"><img src="/assets/thumbs/dating-social-media.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/dating-in-the-era-of-social-media.html">Dating in the Era of Social Media</a></h3>
+        <p>Boundaries that work, red/green DM examples, and how to use group intel without drama.</p>
+      </div>
+    </article>
+
+    <article class="card">
+      <a href="/blog/crowdsourced-dating-safety-facebook-tea-app.html"><img src="/assets/thumbs/tea-facebook.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/crowdsourced-dating-safety-facebook-tea-app.html">Crowdsourced Dating Safety (Facebook & Tea App)</a></h3>
+        <p>How to use crowdsourced intel for safety without feeding gossip or bias.</p>
+      </div>
+    </article>
+  </section>
+
+  <div class="footer-cta">
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+  </div>
+</main>
+<div id="sr-build">Build: categories-v23</div>
+</body></html>

--- a/blog/green-flags/index.html
+++ b/blog/green-flags/index.html
@@ -1,0 +1,83 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Green Flags — What Healthy Looks Like | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Train your eye for consistency, reciprocity, and emotional safety. Real text examples and checklists.">
+<link rel="canonical" href="https://seenandred.com/blog/green-flags/">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-green:#2ECC71;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.7}
+a{color:#1d9b55;text-underline-offset:3px}
+main{max-width:980px;margin:0 auto;padding:28px 20px 96px}
+h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
+.hero{display:flex;flex-direction:column;gap:6px;margin:6px 0 12px}
+.kicker{display:inline-block;background:var(--sr-green);color:#fff;border-radius:999px;padding:6px 10px;font:700 .78rem/1 Lato;text-transform:uppercase;letter-spacing:.02em}
+.grid{display:grid;gap:16px;margin-top:12px}
+@media(min-width:840px){.grid{grid-template-columns:1fr 1fr}}
+.card{border:1px solid var(--sr-border);border-radius:12px;overflow:hidden;background:#fff;display:flex;flex-direction:column}
+.card-body{padding:14px}
+.card h3{margin:.1rem 0 .25rem;font-size:1.15rem}
+.card p{margin:.25rem 0;color:var(--sr-muted)}
+.btn{display:inline-block;background:#1d9b55;color:#fff;padding:10px 14px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{opacity:.9}
+.footer-cta{margin-top:24px}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato}
+</style>
+<meta property="og:title" content="Green Flags — What Healthy Looks Like">
+<meta property="og:description" content="Consistency, reciprocity, and safety in action.">
+<meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/green-flags/">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{
+"@context":"https://schema.org",
+"@type":"CollectionPage",
+"name":"Green Flags — What Healthy Looks Like",
+"description":"Consistency, reciprocity, and emotional safety in action.",
+"mainEntity":{
+  "@type":"ItemList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,
+     "url":"https://seenandred.com/blog/missing-green-flags.html",
+     "name":"Missing Green Flags"},
+    {"@type":"ListItem","position":2,
+     "url":"https://seenandred.com/blog/red-vs-green-texts.html",
+     "name":"Red Flag Texts vs. Green Flag Texts"}
+  ]
+}
+}
+</script>
+</head><body>
+<main>
+  <div class="hero">
+    <span class="kicker">Green Flags</span>
+    <h1>Green Flags: The Small Signs That Predict Real Love</h1>
+    <p>Red flags scream. Green flags whisper. Learn to hear consistency, reciprocity, and repair in everyday messages.</p>
+  </div>
+
+  <section class="grid" aria-label="Articles">
+    <article class="card">
+      <a href="/blog/missing-green-flags.html"><img src="/assets/thumbs/missing-green-flags.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/missing-green-flags.html">Missing Green Flags</a></h3>
+        <p>Why healthy can feel “boring,” plus a checklist for noticing safety and reciprocity.</p>
+      </div>
+    </article>
+
+    <article class="card">
+      <a href="/blog/red-vs-green-texts.html"><img src="/assets/thumbs/red-vs-green-texts.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/red-vs-green-texts.html">Red Flag Texts vs. Green Flag Texts</a></h3>
+        <p>15 matched examples that show what healthy looks like in DMs.</p>
+      </div>
+    </article>
+  </section>
+
+  <div class="footer-cta">
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+  </div>
+</main>
+<div id="sr-build">Build: categories-v23</div>
+</body></html>

--- a/blog/patterns-psychology/index.html
+++ b/blog/patterns-psychology/index.html
@@ -1,0 +1,94 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Patterns & Psychology — Attachment, Intuition & Receipts | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Attachment styles, intuition vs anxiety, and text-pattern analysis to date wiser.">
+<link rel="canonical" href="https://seenandred.com/blog/patterns-psychology/">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-violet:#6C63FF;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.7}
+a{color:#5b4dff;text-underline-offset:3px}
+main{max-width:980px;margin:0 auto;padding:28px 20px 96px}
+h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
+.hero{display:flex;flex-direction:column;gap:6px;margin:6px 0 12px}
+.kicker{display:inline-block;background:var(--sr-violet);color:#fff;border-radius:999px;padding:6px 10px;font:700 .78rem/1 Lato;text-transform:uppercase;letter-spacing:.02em}
+.grid{display:grid;gap:16px;margin-top:12px}
+@media(min-width:840px){.grid{grid-template-columns:1fr 1fr}}
+.card{border:1px solid var(--sr-border);border-radius:12px;overflow:hidden;background:#fff;display:flex;flex-direction:column}
+.card-body{padding:14px}
+.card h3{margin:.1rem 0 .25rem;font-size:1.15rem}
+.card p{margin:.25rem 0;color:var(--sr-muted)}
+.btn{display:inline-block;background:#5b4dff;color:#fff;padding:10px 14px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{opacity:.9}
+.footer-cta{margin-top:24px}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato}
+</style>
+<meta property="og:title" content="Patterns & Psychology — Attachment, Intuition & Receipts">
+<meta property="og:description" content="Attachment, intuition vs anxiety, and text-pattern analysis.">
+<meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/patterns-psychology/">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{
+"@context":"https://schema.org",
+"@type":"CollectionPage",
+"name":"Patterns & Psychology — Attachment, Intuition & Receipts",
+"description":"Attachment styles, intuition vs anxiety, and text-pattern analysis.",
+"mainEntity":{
+  "@type":"ItemList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,
+     "url":"https://seenandred.com/blog/healing-your-patterns.html",
+     "name":"Healing Your Patterns"},
+    {"@type":"ListItem","position":2,
+     "url":"https://seenandred.com/blog/trust-your-intuition.html",
+     "name":"Trust Your Intuition"},
+    {"@type":"ListItem","position":3,
+     "url":"https://seenandred.com/blog/red-vs-green-texts.html",
+     "name":"Red Flag Texts vs. Green Flag Texts"}
+  ]
+}
+}
+</script>
+</head><body>
+<main>
+  <div class="hero">
+    <span class="kicker">Patterns &amp; Psychology</span>
+    <h1>Attachment, Intuition &amp; Receipts: The Science of Better Choices</h1>
+    <p>Understand your wiring, separate gut from anxiety, and analyze <em>patterns</em> in your messages — not just one line.</p>
+  </div>
+
+  <section class="grid" aria-label="Articles">
+    <article class="card">
+      <a href="/blog/healing-your-patterns.html"><img src="/assets/thumbs/healing-your-patterns.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/healing-your-patterns.html">Healing Your Patterns</a></h3>
+        <p>Why we repeat what hurts and how to choose steady‑safe over thrilling‑chaotic.</p>
+      </div>
+    </article>
+
+    <article class="card">
+      <a href="/blog/trust-your-intuition.html"><img src="/assets/thumbs/trust-your-intuition.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/trust-your-intuition.html">Trust Your Intuition</a></h3>
+        <p>A 4‑step gut check to separate intuition from anxiety, with real text examples.</p>
+      </div>
+    </article>
+
+    <article class="card">
+      <a href="/blog/red-vs-green-texts.html"><img src="/assets/thumbs/red-vs-green-texts.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/red-vs-green-texts.html">Red Flag Texts vs. Green Flag Texts</a></h3>
+        <p>15 paired examples to train your eye for safety and reciprocity.</p>
+      </div>
+    </article>
+  </section>
+
+  <div class="footer-cta">
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+  </div>
+</main>
+<div id="sr-build">Build: categories-v23</div>
+</body></html>

--- a/blog/red-flags/index.html
+++ b/blog/red-flags/index.html
@@ -1,0 +1,83 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Red Flag Radar — Articles on Dating Red Flags | Seen & Red</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Learn to spot and act on dating red flags with psychology-backed guides and real text examples.">
+<link rel="canonical" href="https://seenandred.com/blog/red-flags/">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root{--sr-red:#E63946;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
+html,body{margin:0;background:#fff;color:var(--sr-ink)}
+body{font-family:"Lato",system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.7}
+a{color:var(--sr-red);text-underline-offset:3px}
+main{max-width:980px;margin:0 auto;padding:28px 20px 96px}
+h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
+.hero{display:flex;flex-direction:column;gap:6px;margin:6px 0 12px}
+.kicker{display:inline-block;background:var(--sr-red);color:#fff;border-radius:999px;padding:6px 10px;font:700 .78rem/1 Lato;text-transform:uppercase;letter-spacing:.02em}
+.grid{display:grid;gap:16px;margin-top:12px}
+@media(min-width:840px){.grid{grid-template-columns:1fr 1fr}}
+.card{border:1px solid var(--sr-border);border-radius:12px;overflow:hidden;background:#fff;display:flex;flex-direction:column}
+.card-body{padding:14px}
+.card h3{margin:.1rem 0 .25rem;font-size:1.15rem}
+.card p{margin:.25rem 0;color:var(--sr-muted)}
+.btn{display:inline-block;background:var(--sr-red);color:#fff;padding:10px 14px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
+.btn:hover{opacity:.9}
+.footer-cta{margin-top:24px}
+#sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato}
+</style>
+<meta property="og:title" content="Red Flag Radar — Articles on Dating Red Flags">
+<meta property="og:description" content="Psych-backed guides and real text examples to spot red flags sooner.">
+<meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/red-flags/">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{
+"@context":"https://schema.org",
+"@type":"CollectionPage",
+"name":"Red Flag Radar — Articles on Dating Red Flags",
+"description":"Psych-backed guides and real text examples to spot red flags sooner.",
+"mainEntity":{
+  "@type":"ItemList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,
+     "url":"https://seenandred.com/blog/ignoring-red-flags.html",
+     "name":"Ignoring Red Flags"},
+    {"@type":"ListItem","position":2,
+     "url":"https://seenandred.com/blog/red-vs-green-texts.html",
+     "name":"Red Flag Texts vs. Green Flag Texts"}
+  ]
+}
+}
+</script>
+</head><body>
+<main>
+  <div class="hero">
+    <span class="kicker">Red Flag Radar</span>
+    <h1>Dating Red Flags: See Them, Believe Them, Act Early</h1>
+    <p>Red flags hide in repetition. Use these guides and message examples to protect your peace and choose better.</p>
+  </div>
+
+  <section class="grid" aria-label="Articles">
+    <article class="card">
+      <a href="/blog/ignoring-red-flags.html"><img src="/assets/thumbs/ignoring-red-flags.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/ignoring-red-flags.html">Ignoring Red Flags</a></h3>
+        <p>Cognitive dissonance, sunk cost, and how to make standards stick — with healthier script swaps.</p>
+      </div>
+    </article>
+
+    <article class="card">
+      <a href="/blog/red-vs-green-texts.html"><img src="/assets/thumbs/red-vs-green-texts.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <div class="card-body">
+        <h3><a href="/blog/red-vs-green-texts.html">Red Flag Texts vs. Green Flag Texts</a></h3>
+        <p>15 side‑by‑side examples that separate manipulation from maturity — with the psychology behind each.</p>
+      </div>
+    </article>
+  </section>
+
+  <div class="footer-cta">
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
+    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+  </div>
+</main>
+<div id="sr-build">Build: categories-v23</div>
+</body></html>


### PR DESCRIPTION
## Summary
- add Red Flag Radar collection page linking to red flag guides
- add Green Flags category page with article examples
- introduce Dating Culture page covering social trends
- add Patterns & Psychology page about attachment and intuition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a917182390832691d9a13db2f740cc