### PR TITLE
Use remote OG/hero/thumb images (Unsplash CDN) — binary‑free hotfix (v26)

### DIFF
--- a/blog/dating-culture/index.html
+++ b/blog/dating-culture/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Dating Culture — Social Media, Trends & Crowd Intel">
 <meta property="og:description" content="Social platforms and trends that shape modern dating.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/dating-culture/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -58,7 +61,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 
   <section class="grid" aria-label="Articles">
     <article class="card">
-      <a href="/blog/dating-in-the-era-of-social-media.html"><img src="/assets/thumbs/dating-social-media.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <a href="/blog/dating-in-the-era-of-social-media.html"><img src="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/dating-in-the-era-of-social-media.html">Dating in the Era of Social Media</a></h3>
         <p>Boundaries that work, red/green DM examples, and how to use group intel without drama.</p>
@@ -66,7 +69,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     </article>
 
     <article class="card">
-      <a href="/blog/crowdsourced-dating-safety-facebook-tea-app.html"><img src="/assets/thumbs/tea-facebook.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+      <a href="/blog/crowdsourced-dating-safety-facebook-tea-app.html"><div style="width:100%;height:auto;aspect-ratio:16/9;background:linear-gradient(135deg,#fff 0%,#fdecef 100%);display:grid;place-items:center;font-family:'Playfair Display',Georgia,serif;font-size:18px;color:#C8102E;">Seen &amp; Red</div></a>
       <div class="card-body">
         <h3><a href="/blog/crowdsourced-dating-safety-facebook-tea-app.html">Crowdsourced Dating Safety (Facebook & Tea App)</a></h3>
         <p>How to use crowdsourced intel for safety without feeding gossip or bias.</p>
@@ -79,5 +82,5 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/dating-in-the-era-of-social-media.html
+++ b/blog/dating-in-the-era-of-social-media.html
@@ -32,6 +32,9 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Dating in the Era of Social Media">
 <meta property="og:description" content="Boundaries that work, red/green DM examples, and how to use group intel without drama.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/dating-in-the-era-of-social-media.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Dating in the Era of Social Media","datePublished":"2025-08-20","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Boundaries that work, red/green DM examples, and how to use group intel without drama."}</script>
 </head><body>
@@ -99,5 +102,5 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/green-flags/index.html
+++ b/blog/green-flags/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Green Flags — What Healthy Looks Like">
 <meta property="og:description" content="Consistency, reciprocity, and safety in action.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/green-flags/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1492496913980-501348b61469?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -58,7 +61,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 
   <section class="grid" aria-label="Articles">
     <article class="card">
-      <a href="/blog/missing-green-flags.html"><img src="/assets/thumbs/missing-green-flags.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/missing-green-flags.html"><img src="https://images.unsplash.com/photo-1492496913980-501348b61469?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/missing-green-flags.html">Missing Green Flags</a></h3>
         <p>Why healthy can feel “boring,” plus a checklist for noticing safety and reciprocity.</p>
@@ -66,7 +69,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     </article>
 
     <article class="card">
-      <a href="/blog/red-vs-green-texts.html"><img src="/assets/thumbs/red-vs-green-texts.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/red-vs-green-texts.html"><img src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/red-vs-green-texts.html">Red Flag Texts vs. Green Flag Texts</a></h3>
         <p>15 matched examples that show what healthy looks like in DMs.</p>
@@ -79,5 +82,5 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/healing-your-patterns.html
+++ b/blog/healing-your-patterns.html
@@ -37,6 +37,9 @@ ul,ol{margin:10px 0 18px 22px}
 <meta property="og:title" content="Healing Your Patterns: Breaking the Cycle">
 <meta property="og:description" content="Attachment, trauma bonds, and practical steps to change repeated relationship choices.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/healing-your-patterns.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Healing Your Patterns: Breaking the Cycle","datePublished":"2024-06-15","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Attachment, trauma bonds, and practical steps to change repeated relationship choices."}</script>
 </head><body>
@@ -133,5 +136,5 @@ ul,ol{margin:10px 0 18px 22px}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/ignoring-red-flags.html
+++ b/blog/ignoring-red-flags.html
@@ -32,6 +32,9 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Ignoring Red Flags">
 <meta property="og:description" content="From excuses to standards — spot patterns early and act sooner.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/ignoring-red-flags.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Ignoring Red Flags","datePublished":"2024-08-08","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why we rationalize and how to act sooner with clear standards."}</script>
 </head><body>
@@ -98,5 +101,5 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -98,7 +98,7 @@ html,body{margin:0}
     <!-- Social Media — Dating Culture -->
     <article class="post-card" data-category="culture">
       <a class="post-link" href="/blog/dating-in-the-era-of-social-media.html?v=18" aria-label="Read: Dating in the Era of Social Media">
-        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <img class="post-thumb" src="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
           <div class="blog-meta category-culture">Dating Culture</div>
           <h3 class="post-title">Dating in the Era of Social Media</h3>
@@ -111,7 +111,7 @@ html,body{margin:0}
     <!-- Red vs. Green Texts — Patterns & Psychology -->
     <article class="post-card" data-category="psych">
       <a class="post-link" href="/blog/red-vs-green-texts.html?v=18" aria-label="Read: Red Flag Texts vs. Green Flag Texts">
-        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <img class="post-thumb" src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
           <div class="blog-meta category-psych">Patterns &amp; Psychology</div>
           <h3 class="post-title">Red Flag Texts vs. Green Flag Texts</h3>
@@ -124,7 +124,7 @@ html,body{margin:0}
     <!-- Facebook & Tea — Dating Culture (new title if you adopted it) -->
     <article class="post-card" data-category="culture">
       <a class="post-link" href="/blog/crowdsourced-dating-safety-facebook-tea-app.html?v=18" aria-label="Read: Crowdsourced Dating Safety: Facebook Groups &amp; Tea App">
-        <div class="post-thumb placeholder">Seen &amp; Red</div>
+          <div class="post-thumb placeholder">Seen &amp; Red</div>
         <div class="post-body">
           <div class="blog-meta category-culture">Dating Culture</div>
           <h3 class="post-title">Crowdsourced Dating Safety: Facebook Groups &amp; Tea App</h3>
@@ -137,7 +137,7 @@ html,body{margin:0}
     <!-- Healing Your Patterns — Patterns & Psychology -->
     <article class="post-card" data-category="psych">
       <a class="post-link" href="/blog/healing-your-patterns.html?v=18" aria-label="Read: Healing Your Patterns">
-        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <img class="post-thumb" src="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
           <div class="blog-meta category-psych">Patterns &amp; Psychology</div>
           <h3 class="post-title">Healing Your Patterns: Breaking the Cycle</h3>
@@ -150,7 +150,7 @@ html,body{margin:0}
     <!-- Trust Your Intuition — Patterns & Psychology -->
     <article class="post-card" data-category="psych">
       <a class="post-link" href="/blog/trust-your-intuition.html?v=18" aria-label="Read: Trust Your Intuition">
-        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <img class="post-thumb" src="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
           <div class="blog-meta category-psych">Patterns &amp; Psychology</div>
           <h3 class="post-title">Trust Your Intuition</h3>
@@ -163,7 +163,7 @@ html,body{margin:0}
     <!-- Missing Green Flags — Green Flags -->
     <article class="post-card" data-category="green">
       <a class="post-link" href="/blog/missing-green-flags.html?v=18" aria-label="Read: Missing Green Flags">
-        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <img class="post-thumb" src="https://images.unsplash.com/photo-1492496913980-501348b61469?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
           <div class="blog-meta category-green">Green Flags</div>
           <h3 class="post-title">Missing Green Flags</h3>
@@ -176,7 +176,7 @@ html,body{margin:0}
     <!-- Ignoring Red Flags — Red Flag Radar -->
     <article class="post-card" data-category="red">
       <a class="post-link" href="/blog/ignoring-red-flags.html?v=18" aria-label="Read: Ignoring Red Flags">
-        <div class="post-thumb placeholder">Seen &amp; Red</div>
+        <img class="post-thumb" src="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
           <div class="blog-meta category-red">Red Flag Radar</div>
           <h3 class="post-title">Ignoring Red Flags</h3>
@@ -197,9 +197,9 @@ html,body{margin:0}
   </div>
 </div>
 
-<div id="sr-build-badge" style="position:fixed;right:12px;bottom:12px;z-index:9999;background:#1A1A1A;color:#fff;border-radius:999px;padding:8px 12px;font:600 12px/1 Lato,system-ui">
-  Seen &amp; Red • Blog Build v22
-</div>
+  <div id="sr-build-badge" style="position:fixed;right:12px;bottom:12px;z-index:9999;background:#1A1A1A;color:#fff;border-radius:999px;padding:8px 12px;font:600 12px/1 Lato,system-ui">
+    Seen &amp; Red • Blog Build v26
+  </div>
 
 <script>
 (function(){

--- a/blog/missing-green-flags.html
+++ b/blog/missing-green-flags.html
@@ -32,6 +32,9 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Missing Green Flags">
 <meta property="og:description" content="A checklist for recognizing healthy effort, emotional safety, and reciprocity.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/missing-green-flags.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1492496913980-501348b61469?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Missing Green Flags","datePublished":"2024-07-30","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why negativity bias hides green flags and how to notice steady, reciprocal love."}</script>
 </head><body>
@@ -105,5 +108,5 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/patterns-psychology/index.html
+++ b/blog/patterns-psychology/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Patterns & Psychology — Attachment, Intuition & Receipts">
 <meta property="og:description" content="Attachment, intuition vs anxiety, and text-pattern analysis.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/patterns-psychology/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -61,7 +64,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 
   <section class="grid" aria-label="Articles">
     <article class="card">
-      <a href="/blog/healing-your-patterns.html"><img src="/assets/thumbs/healing-your-patterns.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/healing-your-patterns.html"><img src="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/healing-your-patterns.html">Healing Your Patterns</a></h3>
         <p>Why we repeat what hurts and how to choose steady‑safe over thrilling‑chaotic.</p>
@@ -69,7 +72,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     </article>
 
     <article class="card">
-      <a href="/blog/trust-your-intuition.html"><img src="/assets/thumbs/trust-your-intuition.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/trust-your-intuition.html"><img src="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/trust-your-intuition.html">Trust Your Intuition</a></h3>
         <p>A 4‑step gut check to separate intuition from anxiety, with real text examples.</p>
@@ -77,7 +80,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     </article>
 
     <article class="card">
-      <a href="/blog/red-vs-green-texts.html"><img src="/assets/thumbs/red-vs-green-texts.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/red-vs-green-texts.html"><img src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/red-vs-green-texts.html">Red Flag Texts vs. Green Flag Texts</a></h3>
         <p>15 paired examples to train your eye for safety and reciprocity.</p>
@@ -90,5 +93,5 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/red-flags/index.html
+++ b/blog/red-flags/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Red Flag Radar — Articles on Dating Red Flags">
 <meta property="og:description" content="Psych-backed guides and real text examples to spot red flags sooner.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/red-flags/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -58,7 +61,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 
   <section class="grid" aria-label="Articles">
     <article class="card">
-      <a href="/blog/ignoring-red-flags.html"><img src="/assets/thumbs/ignoring-red-flags.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/ignoring-red-flags.html"><img src="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/ignoring-red-flags.html">Ignoring Red Flags</a></h3>
         <p>Cognitive dissonance, sunk cost, and how to make standards stick — with healthier script swaps.</p>
@@ -66,7 +69,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     </article>
 
     <article class="card">
-      <a href="/blog/red-vs-green-texts.html"><img src="/assets/thumbs/red-vs-green-texts.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/red-vs-green-texts.html"><img src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/red-vs-green-texts.html">Red Flag Texts vs. Green Flag Texts</a></h3>
         <p>15 side‑by‑side examples that separate manipulation from maturity — with the psychology behind each.</p>
@@ -79,5 +82,5 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/red-vs-green-texts.html
+++ b/blog/red-vs-green-texts.html
@@ -40,6 +40,9 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Red Flag Texts vs. Green Flag Texts">
 <meta property="og:description" content="15 texting examples that separate manipulation from maturity — with the psychology behind each.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/red-vs-green-texts.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs","datePublished":"2025-08-22","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"15 texting examples with psychological explanations."}</script>
 </head><body>
@@ -118,5 +121,5 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<div id="sr-build">Build v26</div>
 </body></html>

--- a/blog/trust-your-intuition.html
+++ b/blog/trust-your-intuition.html
@@ -32,6 +32,9 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Trust Your Intuition">
 <meta property="og:description" content="A quick gut‑check framework to separate intuition from anxiety, with real text examples.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/trust-your-intuition.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Trust Your Intuition","datePublished":"2024-07-10","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"A 4‑step gut check to separate intuition from anxiety, with examples."}</script>
 </head><body>
@@ -106,5 +109,5 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<div id="sr-build">Build v26</div>
 </body></html>


### PR DESCRIPTION
## Summary
- swap local blog post images for Unsplash-hosted OG and hero URLs
- serve category and index thumbnails from Unsplash; show placeholder where no mapping exists
- bump visible build badges to **Build v26**

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a92bbb485c8326a4cf99697afa8919