### PR TITLE
SEO Upgrades: category block, richer schema, sitemap

### DIFF
--- a/blog/dating-culture/index.html
+++ b/blog/dating-culture/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Dating Culture — Social Media, Trends & Crowd Intel">
 <meta property="og:description" content="Social platforms and trends that shape modern dating.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/dating-culture/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -77,7 +80,17 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   <div class="footer-cta">
     <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
-  </div>
+</div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Dating Culture","item":"https://seenandred.com/blog/dating-culture/"}
+  ]
+}
+</script>
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/dating-in-the-era-of-social-media.html
+++ b/blog/dating-in-the-era-of-social-media.html
@@ -32,8 +32,28 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Dating in the Era of Social Media">
 <meta property="og:description" content="Boundaries that work, red/green DM examples, and how to use group intel without drama.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/dating-in-the-era-of-social-media.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Dating in the Era of Social Media","datePublished":"2025-08-20","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Boundaries that work, red/green DM examples, and how to use group intel without drama."}</script>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BlogPosting",
+  "headline":"Dating in the Era of Social Media: How Likes, DMs & Group Chats Rewrite the Rules",
+  "description":"Social media can help you find your person — and turbo-charge jealousy. Learn boundaries that work, red/green DM examples, and how to use group intel without drama.",
+  "datePublished":"2025-08-20",
+  "dateModified":"2025-08-20",
+  "author":{"@type":"Organization","name":"Seen & Red"},
+  "publisher":{
+    "@type":"Organization",
+    "name":"Seen & Red",
+    "logo":{"@type":"ImageObject","url":"https://seenandred.com/favicon.ico","width":64,"height":64}
+  },
+  "image":"https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&h=630&fit=crop&q=80",
+  "mainEntityOfPage":{"@type":"WebPage","@id":"https://seenandred.com/blog/dating-in-the-era-of-social-media.html"}
+}
+</script>
 </head><body>
 <main class="sr-article">
 <h1>Dating in the Era of Social Media: How Likes, DMs &amp; Group Chats Rewrite the Rules</h1>
@@ -99,5 +119,35 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Dating Culture","item":"https://seenandred.com/blog/dating-culture/"},
+    {"@type":"ListItem","position":3,"name":"Dating in the Era of Social Media: How Likes, DMs & Group Chats Rewrite the Rules","item":"https://seenandred.com/blog/dating-in-the-era-of-social-media.html"}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "name":"Unlimited Message Analysis",
+  "brand":"Seen & Red",
+  "description":"Upload message threads for psychological pattern analysis, red/green flag detection, and boundary guidance.",
+  "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00",
+  "offers":{
+    "@type":"Offer",
+    "priceCurrency":"USD",
+    "price":"12.00",
+    "availability":"https://schema.org/InStock",
+    "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
+  }
+}
+</script>
+
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/green-flags/index.html
+++ b/blog/green-flags/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Green Flags — What Healthy Looks Like">
 <meta property="og:description" content="Consistency, reciprocity, and safety in action.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/green-flags/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1492496913980-501348b61469?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -77,7 +80,17 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   <div class="footer-cta">
     <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
-  </div>
+</div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Green Flags","item":"https://seenandred.com/blog/green-flags/"}
+  ]
+}
+</script>
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/healing-your-patterns.html
+++ b/blog/healing-your-patterns.html
@@ -37,8 +37,28 @@ ul,ol{margin:10px 0 18px 22px}
 <meta property="og:title" content="Healing Your Patterns: Breaking the Cycle">
 <meta property="og:description" content="Attachment, trauma bonds, and practical steps to change repeated relationship choices.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/healing-your-patterns.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Healing Your Patterns: Breaking the Cycle","datePublished":"2024-06-15","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Attachment, trauma bonds, and practical steps to change repeated relationship choices."}</script>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BlogPosting",
+  "headline":"Healing Your Patterns: Breaking the Cycle",
+  "description":"Why we repeat relationship patterns (attachment, trauma bonds) and how to retrain your nervous system, boundaries, and choices so healthy love feels familiar.",
+  "datePublished":"2024-06-15",
+  "dateModified":"2024-06-15",
+  "author":{"@type":"Organization","name":"Seen & Red"},
+  "publisher":{
+    "@type":"Organization",
+    "name":"Seen & Red",
+    "logo":{"@type":"ImageObject","url":"https://seenandred.com/favicon.ico","width":64,"height":64}
+  },
+  "image":"https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80",
+  "mainEntityOfPage":{"@type":"WebPage","@id":"https://seenandred.com/blog/healing-your-patterns.html"}
+}
+</script>
 </head><body>
 <main class="sr-article">
 <h1>Healing Your Patterns: Breaking the Cycle</h1>
@@ -133,5 +153,35 @@ ul,ol{margin:10px 0 18px 22px}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Patterns & Psychology","item":"https://seenandred.com/blog/patterns-psychology/"},
+    {"@type":"ListItem","position":3,"name":"Healing Your Patterns: Breaking the Cycle","item":"https://seenandred.com/blog/healing-your-patterns.html"}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "name":"Unlimited Message Analysis",
+  "brand":"Seen & Red",
+  "description":"Upload message threads for psychological pattern analysis, red/green flag detection, and boundary guidance.",
+  "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00",
+  "offers":{
+    "@type":"Offer",
+    "priceCurrency":"USD",
+    "price":"12.00",
+    "availability":"https://schema.org/InStock",
+    "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
+  }
+}
+</script>
+
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/ignoring-red-flags.html
+++ b/blog/ignoring-red-flags.html
@@ -32,8 +32,28 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Ignoring Red Flags">
 <meta property="og:description" content="From excuses to standards — spot patterns early and act sooner.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/ignoring-red-flags.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Ignoring Red Flags","datePublished":"2024-08-08","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why we rationalize and how to act sooner with clear standards."}</script>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BlogPosting",
+  "headline":"Ignoring Red Flags",
+  "description":"Cognitive dissonance, sunk cost, and hope psychology — why we justify what hurts and how to act sooner with clear standards.",
+  "datePublished":"2024-08-08",
+  "dateModified":"2024-08-08",
+  "author":{"@type":"Organization","name":"Seen & Red"},
+  "publisher":{
+    "@type":"Organization",
+    "name":"Seen & Red",
+    "logo":{"@type":"ImageObject","url":"https://seenandred.com/favicon.ico","width":64,"height":64}
+  },
+  "image":"https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1200&h=630&fit=crop&q=80",
+  "mainEntityOfPage":{"@type":"WebPage","@id":"https://seenandred.com/blog/ignoring-red-flags.html"}
+}
+</script>
 </head><body>
 <main class="sr-article">
 <h1>Ignoring Red Flags</h1>
@@ -98,5 +118,35 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Red Flag Radar","item":"https://seenandred.com/blog/red-flags/"},
+    {"@type":"ListItem","position":3,"name":"Ignoring Red Flags","item":"https://seenandred.com/blog/ignoring-red-flags.html"}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "name":"Unlimited Message Analysis",
+  "brand":"Seen & Red",
+  "description":"Upload message threads for psychological pattern analysis, red/green flag detection, and boundary guidance.",
+  "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00",
+  "offers":{
+    "@type":"Offer",
+    "priceCurrency":"USD",
+    "price":"12.00",
+    "availability":"https://schema.org/InStock",
+    "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
+  }
+}
+</script>
+
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -74,6 +74,17 @@ html,body{margin:0}
 .category-legend .pill.coral{ background:#FF6B6B; }
 .category-legend .pill.violet{ background:#6C63FF; }
 
+.browse-categories{margin:12px 0 20px}
+.browse-title{font-family:"Playfair Display",Georgia,serif;font-size:1.4rem;margin:.3rem 0 .6rem}
+.browse-grid{display:grid;gap:12px}
+@media(min-width:840px){.browse-grid{grid-template-columns:repeat(4,1fr)}}
+.browse-card{display:flex;flex-direction:column;gap:6px;border-radius:14px;padding:14px 12px;text-decoration:none;color:#fff;min-height:96px}
+.browse-card .kicker{font:700 .75rem/1 Lato,sans-serif;text-transform:uppercase;opacity:.95}
+.browse-card strong{font:700 1rem/1.2 Lato,sans-serif}
+.browse-card.red{background:#E63946}.browse-card.green{background:#2ECC71}
+.browse-card.coral{background:#FF6B6B}.browse-card.violet{background:#6C63FF}
+.browse-card:hover{filter:brightness(.96);transform:translateY(-1px);transition:all .12s ease}
+
 /* Filter animation */
 .post-card{ transition:opacity .12s ease, transform .12s ease; }
 .post-card.is-hidden{ opacity:0; transform:scale(.98); pointer-events:none; position:relative; }
@@ -93,6 +104,24 @@ html,body{margin:0}
     <a class="pill coral" href="?cat=culture" data-filter="culture">Dating Culture</a>
     <a class="pill violet" href="?cat=psych" data-filter="psych">Patterns &amp; Psychology</a>
   </div>
+
+  <section class="browse-categories" aria-label="Browse by Category">
+    <h2 class="browse-title">Browse by Category</h2>
+    <div class="browse-grid">
+      <a class="browse-card red" href="/blog/red-flags/">
+        <span class="kicker">Red Flag Radar</span><strong>Spot &amp; Act Early</strong>
+      </a>
+      <a class="browse-card green" href="/blog/green-flags/">
+        <span class="kicker">Green Flags</span><strong>What Healthy Looks Like</strong>
+      </a>
+      <a class="browse-card coral" href="/blog/dating-culture/">
+        <span class="kicker">Dating Culture</span><strong>Social Media &amp; Trends</strong>
+      </a>
+      <a class="browse-card violet" href="/blog/patterns-psychology/">
+        <span class="kicker">Patterns &amp; Psychology</span><strong>Attachment, Intuition &amp; Receipts</strong>
+      </a>
+    </div>
+  </section>
 
   <section class="post-grid">
     <!-- Social Media — Dating Culture -->
@@ -198,7 +227,7 @@ html,body{margin:0}
 </div>
 
 <div id="sr-build-badge" style="position:fixed;right:12px;bottom:12px;z-index:9999;background:#1A1A1A;color:#fff;border-radius:999px;padding:8px 12px;font:600 12px/1 Lato,system-ui">
-  Seen &amp; Red • Blog Build v22
+  Seen &amp; Red • Blog Build v26
 </div>
 
 <script>

--- a/blog/missing-green-flags.html
+++ b/blog/missing-green-flags.html
@@ -32,8 +32,28 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Missing Green Flags">
 <meta property="og:description" content="A checklist for recognizing healthy effort, emotional safety, and reciprocity.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/missing-green-flags.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1492496913980-501348b61469?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Missing Green Flags","datePublished":"2024-07-30","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why negativity bias hides green flags and how to notice steady, reciprocal love."}</script>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BlogPosting",
+  "headline":"Missing Green Flags",
+  "description":"Why healthy can feel boring, how negativity bias hides green flags, and a practical checklist to notice steady, reciprocal love.",
+  "datePublished":"2024-07-30",
+  "dateModified":"2024-07-30",
+  "author":{"@type":"Organization","name":"Seen & Red"},
+  "publisher":{
+    "@type":"Organization",
+    "name":"Seen & Red",
+    "logo":{"@type":"ImageObject","url":"https://seenandred.com/favicon.ico","width":64,"height":64}
+  },
+  "image":"https://images.unsplash.com/photo-1492496913980-501348b61469?w=1200&h=630&fit=crop&q=80",
+  "mainEntityOfPage":{"@type":"WebPage","@id":"https://seenandred.com/blog/missing-green-flags.html"}
+}
+</script>
 </head><body>
 <main class="sr-article">
 <h1>Missing Green Flags</h1>
@@ -105,5 +125,35 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Green Flags","item":"https://seenandred.com/blog/green-flags/"},
+    {"@type":"ListItem","position":3,"name":"Missing Green Flags","item":"https://seenandred.com/blog/missing-green-flags.html"}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "name":"Unlimited Message Analysis",
+  "brand":"Seen & Red",
+  "description":"Upload message threads for psychological pattern analysis, red/green flag detection, and boundary guidance.",
+  "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00",
+  "offers":{
+    "@type":"Offer",
+    "priceCurrency":"USD",
+    "price":"12.00",
+    "availability":"https://schema.org/InStock",
+    "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
+  }
+}
+</script>
+
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/patterns-psychology/index.html
+++ b/blog/patterns-psychology/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Patterns & Psychology — Attachment, Intuition & Receipts">
 <meta property="og:description" content="Attachment, intuition vs anxiety, and text-pattern analysis.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/patterns-psychology/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -88,7 +91,17 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   <div class="footer-cta">
     <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
-  </div>
+</div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Patterns & Psychology","item":"https://seenandred.com/blog/patterns-psychology/"}
+  ]
+}
+</script>
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/red-flags/index.html
+++ b/blog/red-flags/index.html
@@ -29,6 +29,9 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Red Flag Radar — Articles on Dating Red Flags">
 <meta property="og:description" content="Psych-backed guides and real text examples to spot red flags sooner.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/red-flags/">
+<meta property="og:image" content="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -77,7 +80,17 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   <div class="footer-cta">
     <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
     <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
-  </div>
+</div>
 </main>
-<div id="sr-build">Build: categories-v23</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Red Flag Radar","item":"https://seenandred.com/blog/red-flags/"}
+  ]
+}
+</script>
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/red-vs-green-texts.html
+++ b/blog/red-vs-green-texts.html
@@ -40,8 +40,28 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Red Flag Texts vs. Green Flag Texts">
 <meta property="og:description" content="15 texting examples that separate manipulation from maturity — with the psychology behind each.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/red-vs-green-texts.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs","datePublished":"2025-08-22","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"15 texting examples with psychological explanations."}</script>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BlogPosting",
+  "headline":"Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs",
+  "description":"15 real‑world texting examples that separate manipulation from maturity — with the psychology behind each.",
+  "datePublished":"2025-08-22",
+  "dateModified":"2025-08-22",
+  "author":{"@type":"Organization","name":"Seen & Red"},
+  "publisher":{
+    "@type":"Organization",
+    "name":"Seen & Red",
+    "logo":{"@type":"ImageObject","url":"https://seenandred.com/favicon.ico","width":64,"height":64}
+  },
+  "image":"https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=1200&h=630&fit=crop&q=80",
+  "mainEntityOfPage":{"@type":"WebPage","@id":"https://seenandred.com/blog/red-vs-green-texts.html"}
+}
+</script>
 </head><body>
 <main class="sr-article">
 <h1>Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs</h1>
@@ -118,5 +138,35 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Patterns & Psychology","item":"https://seenandred.com/blog/patterns-psychology/"},
+    {"@type":"ListItem","position":3,"name":"Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs","item":"https://seenandred.com/blog/red-vs-green-texts.html"}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "name":"Unlimited Message Analysis",
+  "brand":"Seen & Red",
+  "description":"Upload message threads for psychological pattern analysis, red/green flag detection, and boundary guidance.",
+  "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00",
+  "offers":{
+    "@type":"Offer",
+    "priceCurrency":"USD",
+    "price":"12.00",
+    "availability":"https://schema.org/InStock",
+    "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
+  }
+}
+</script>
+
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>

--- a/blog/sitemap.xml
+++ b/blog/sitemap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Index -->
+  <url><loc>https://seenandred.com/blog/</loc></url>
+
+  <!-- Categories -->
+  <url><loc>https://seenandred.com/blog/red-flags/</loc></url>
+  <url><loc>https://seenandred.com/blog/green-flags/</loc></url>
+  <url><loc>https://seenandred.com/blog/dating-culture/</loc></url>
+  <url><loc>https://seenandred.com/blog/patterns-psychology/</loc></url>
+
+  <!-- Articles -->
+  <url><loc>https://seenandred.com/blog/dating-in-the-era-of-social-media.html</loc></url>
+  <url><loc>https://seenandred.com/blog/healing-your-patterns.html</loc></url>
+  <url><loc>https://seenandred.com/blog/trust-your-intuition.html</loc></url>
+  <url><loc>https://seenandred.com/blog/missing-green-flags.html</loc></url>
+  <url><loc>https://seenandred.com/blog/ignoring-red-flags.html</loc></url>
+  <url><loc>https://seenandred.com/blog/red-vs-green-texts.html</loc></url>
+</urlset>

--- a/blog/trust-your-intuition.html
+++ b/blog/trust-your-intuition.html
@@ -32,8 +32,28 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Trust Your Intuition">
 <meta property="og:description" content="A quick gut‑check framework to separate intuition from anxiety, with real text examples.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/trust-your-intuition.html">
+<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&amp;h=630&amp;fit=crop&amp;q=80">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Trust Your Intuition","datePublished":"2024-07-10","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"A 4‑step gut check to separate intuition from anxiety, with examples."}</script>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BlogPosting",
+  "headline":"Trust Your Intuition",
+  "description":"When to trust your gut in dating — and when anxiety or past hurt is impersonating intuition. A practical 4‑step gut check with real text examples.",
+  "datePublished":"2024-07-10",
+  "dateModified":"2024-07-10",
+  "author":{"@type":"Organization","name":"Seen & Red"},
+  "publisher":{
+    "@type":"Organization",
+    "name":"Seen & Red",
+    "logo":{"@type":"ImageObject","url":"https://seenandred.com/favicon.ico","width":64,"height":64}
+  },
+  "image":"https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80",
+  "mainEntityOfPage":{"@type":"WebPage","@id":"https://seenandred.com/blog/trust-your-intuition.html"}
+}
+</script>
 </head><body>
 <main class="sr-article">
 <h1>Trust Your Intuition</h1>
@@ -106,5 +126,35 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
   ]
 }</script>
 
-<div id="sr-build">Build: article-faq-v20</div>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+    {"@type":"ListItem","position":2,"name":"Patterns & Psychology","item":"https://seenandred.com/blog/patterns-psychology/"},
+    {"@type":"ListItem","position":3,"name":"Trust Your Intuition","item":"https://seenandred.com/blog/trust-your-intuition.html"}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "name":"Unlimited Message Analysis",
+  "brand":"Seen & Red",
+  "description":"Upload message threads for psychological pattern analysis, red/green flag detection, and boundary guidance.",
+  "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00",
+  "offers":{
+    "@type":"Offer",
+    "priceCurrency":"USD",
+    "price":"12.00",
+    "availability":"https://schema.org/InStock",
+    "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
+  }
+}
+</script>
+
+<div id="sr-build">Build: seo‑v26</div>
 </body></html>


### PR DESCRIPTION
## Summary
- Add browse-by-category section with new styles and update blog index badge to Build v26
- Enrich articles with remote OG images, BlogPosting schema, BreadcrumbList, and product offer
- Enhance category pages with OG/Twitter metadata, breadcrumb schema, and add blog sitemap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a92d5c77b4832685a6f52d5f4074b7