### PR TITLE
Hardcode category labels in blog listings

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -65,7 +65,7 @@ html,body{margin:0}
     <!-- Social Media article -->
     <article class="post-card">
       <a class="post-link" href="/blog/dating-in-the-era-of-social-media.html?v=12" aria-label="Read: Dating in the Era of Social Media">
-        <div class="card-header">{{ post.category }}</div>
+        <div class="card-header">Dating Culture</div>
         <div class="post-body">
           <h3 class="post-title">Dating in the Era of Social Media</h3>
           <p class="post-meta">Aug 20, 2025 · ~8 min read</p>
@@ -77,7 +77,7 @@ html,body{margin:0}
     <!-- Are We Dating the Same Guy… Again? (fixed slug) -->
     <article class="post-card">
       <a class="post-link" href="https://seenandred.com/blog/are-we-dating-the-same-guy-again.html?v=15" aria-label="Read: Are We Dating the Same Guy… Again?">
-        <div class="card-header">{{ post.category }}</div>
+        <div class="card-header">Dating Culture</div>
         <div class="post-body">
           <h3 class="post-title">Are We Dating the Same Guy… Again?</h3>
           <p class="post-meta">May 12, 2024 · ~6 min read</p>
@@ -89,7 +89,7 @@ html,body{margin:0}
     <!-- Healing Your Patterns -->
     <article class="post-card">
       <a class="post-link" href="/blog/healing-your-patterns.html" aria-label="Read: Healing Your Patterns">
-        <div class="card-header">{{ post.category }}</div>
+        <div class="card-header">Patterns &amp; Psychology</div>
         <div class="post-body">
           <h3 class="post-title">Healing Your Patterns: Breaking the Cycle</h3>
           <p class="post-meta">Jun 15, 2024 · ~8 min read</p>
@@ -101,7 +101,7 @@ html,body{margin:0}
     <!-- Trust Your Intuition -->
     <article class="post-card">
       <a class="post-link" href="/blog/trust-your-intuition.html" aria-label="Read: Trust Your Intuition">
-        <div class="card-header">{{ post.category }}</div>
+        <div class="card-header">Patterns &amp; Psychology</div>
         <div class="post-body">
           <h3 class="post-title">Trust Your Intuition</h3>
           <p class="post-meta">Jul 10, 2024 · ~7 min read</p>
@@ -113,7 +113,7 @@ html,body{margin:0}
     <!-- Missing Green Flags -->
     <article class="post-card">
       <a class="post-link" href="/blog/missing-green-flags.html" aria-label="Read: Missing Green Flags">
-        <div class="card-header">{{ post.category }}</div>
+        <div class="card-header">Green Flags</div>
         <div class="post-body">
           <h3 class="post-title">Missing Green Flags</h3>
           <p class="post-meta">Jul 30, 2024 · ~5 min read</p>
@@ -125,7 +125,7 @@ html,body{margin:0}
     <!-- Ignoring Red Flags -->
     <article class="post-card">
       <a class="post-link" href="/blog/ignoring-red-flags.html" aria-label="Read: Ignoring Red Flags">
-        <div class="card-header">{{ post.category }}</div>
+        <div class="card-header">Red Flags</div>
         <div class="post-body">
           <h3 class="post-title">Ignoring Red Flags</h3>
           <p class="post-meta">Aug 8, 2024 · ~6 min read</p>

--- a/blog/index.html
+++ b/blog/index.html
@@ -120,12 +120,12 @@ html,body{margin:0}
       </a>
     </article>
 
-    <!-- Red vs. Green Texts — Patterns & Psychology -->
-    <article class="post-card" data-category="psych">
+    <!-- Red vs. Green Texts — Red Flags -->
+    <article class="post-card" data-category="red">
       <a class="post-link" href="/blog/red-vs-green-texts.html?v=18" aria-label="Read: Red Flag Texts vs. Green Flag Texts">
         <img class="post-thumb" src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
-          <div class="blog-meta category-psych">Patterns &amp; Psychology</div>
+          <div class="blog-meta category-red">Red Flags</div>
           <h3 class="post-title">Red Flag Texts vs. Green Flag Texts</h3>
           <p class="post-meta">Aug 22, 2025 · ~10–12 min read</p>
           <p class="post-excerpt">15 side‑by‑side examples that separate manipulation from maturity — with the psychology behind each.</p>
@@ -136,7 +136,7 @@ html,body{margin:0}
     <!-- Facebook & Tea — Dating Culture (new title if you adopted it) -->
     <article class="post-card" data-category="culture">
       <a class="post-link" href="/blog/crowdsourced-dating-safety-facebook-tea-app.html?v=18" aria-label="Read: Crowdsourced Dating Safety: Facebook Groups &amp; Tea App">
-          <div class="card-header">{{ post.category }}</div>
+          <div class="card-header">Dating Culture</div>
         <div class="post-body">
           <div class="blog-meta category-culture">Dating Culture</div>
           <h3 class="post-title">Crowdsourced Dating Safety: Facebook Groups &amp; Tea App</h3>
@@ -185,12 +185,12 @@ html,body{margin:0}
       </a>
     </article>
 
-    <!-- Ignoring Red Flags — Red Flag Radar -->
+    <!-- Ignoring Red Flags — Red Flags -->
     <article class="post-card" data-category="red">
       <a class="post-link" href="/blog/ignoring-red-flags.html?v=18" aria-label="Read: Ignoring Red Flags">
         <img class="post-thumb" src="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=800&h=450&fit=crop&q=80" alt="" loading="lazy">
         <div class="post-body">
-          <div class="blog-meta category-red">Red Flag Radar</div>
+          <div class="blog-meta category-red">Red Flags</div>
           <h3 class="post-title">Ignoring Red Flags</h3>
           <p class="post-meta">Aug 8, 2024 · ~8–10 min read</p>
           <p class="post-excerpt">How past wounds can make manipulation feel like love.</p>

--- a/blog/red-flags/index.html
+++ b/blog/red-flags/index.html
@@ -54,7 +54,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 </head><body>
 <main>
   <div class="hero">
-    <span class="kicker">Red Flag Radar</span>
+    <span class="kicker">Red Flags</span>
     <h1>Dating Red Flags: See Them, Believe Them, Act Early</h1>
     <p>Red flags hide in repetition. Use these guides and message examples to protect your peace and choose better.</p>
   </div>


### PR DESCRIPTION
## Summary
- Hardcode category labels for blog cards and remove `{{ post.category }}` placeholders
- Mark "Red Flag Texts vs. Green Flag Texts" and "Ignoring Red Flags" as Red Flags
- Normalize Red Flags category header on its listing page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9562d5e4c8326b50b29b23bfacdb1