### PR TITLE
Add breadcrumbs and category badges to blog articles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -299,3 +299,21 @@ html, body { margin:0; }
 .blog-inline-nav ul{ list-style:none; padding:0; margin:0 0 10px; display:flex; flex-wrap:wrap; gap:12px; }
 .blog-inline-nav a{ text-decoration:none; color:var(--sr-red); }
 .blog-inline-nav a:hover{ color:var(--sr-red-soft); }
+
+/* Article layout tightening */
+.content, main article, .article-container { max-width: 760px; margin: 0 auto; }
+.breadcrumb { font-size: 14px; color: #6b7280; margin: 16px 0 8px; }
+.breadcrumb a { color: inherit; text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+.breadcrumb .sep { margin: 0 8px; opacity: .6; }
+.breadcrumb .chev { margin: 0 6px; opacity: .6; }
+.back-link { margin-right: 8px; text-decoration: none; }
+
+h1 { margin-top: 8px; margin-bottom: 8px; }
+.article-badges { margin: 6px 0 14px; }
+.badge { display:inline-block; padding:4px 10px; border-radius:999px; font-weight:600; font-size:12px; letter-spacing:.02em; line-height:1.6; }
+.badge-category { background:#eef7f0; color:#1b7d4c; border:1px solid #cfe8d7; text-transform: uppercase; }
+
+article p { margin: 14px 0; }
+article h2 { margin: 28px 0 12px; }
+.callout, .note, .tip { background:#f7f7f8; border:1px solid #ececec; padding:16px 20px; border-radius:12px; }

--- a/blog/dating-in-the-era-of-social-media.html
+++ b/blog/dating-in-the-era-of-social-media.html
@@ -1,6 +1,3 @@
----
-category: "Dating Culture"
----
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8">
 <title>Dating in the Era of Social Media: How Likes, DMs & Group Chats Rewrite the Rules | Seen & Red</title>
@@ -23,13 +20,6 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 .btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
 .btn:hover{background:var(--sr-red-soft)}
 .ref li{margin-bottom:.45rem}
-/* Article-level category pill */
-.article-meta-pill{
-  display:inline-block;margin:.25rem 0 .8rem;padding:6px 10px;
-  font:700 .78rem/1 "Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-  text-transform:uppercase;letter-spacing:.02em;color:#fff;border-radius:999px
-}
-.article-meta-pill.category-culture{background:#FF6B6B}
 #sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
 </style>
 <meta property="og:title" content="Dating in the Era of Social Media">
@@ -39,11 +29,23 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Dating in the Era of Social Media","datePublished":"2025-08-20","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Boundaries that work, red/green DM examples, and how to use group intel without drama."}</script>
 </head><body>
 <main class="sr-article">
+<nav class="breadcrumb">
+  <a class="back-link" href="/blog/">← Back to Blog</a>
+  <span class="sep">·</span>
+  <a href="/blog/">Blog</a>
+  <span class="chev">›</span>
+  <a href="/blog/dating-culture/">Dating Culture</a>
+  <span class="chev">›</span>
+  <span class="current">Dating in the Era of Social Media: How Likes, DMs &amp; Group Chats Rewrite the Rules</span>
+</nav>
 <h1>Dating in the Era of Social Media: How Likes, DMs &amp; Group Chats Rewrite the Rules</h1>
-<div class="article-meta-pill category-culture">Dating Culture</div>
+<div class="article-badges">
+  <span class="badge badge-category">Dating Culture</span>
+</div>
 <p class="meta">Published: August 20, 2025 • ~8–10 min read</p>
 
 <p>Social platforms expand your dating pool and your anxieties. Used well, they’re a safety net. Used poorly, they become a surveillance system. Here’s how to date like a grown‑up in the scroll era.</p>

--- a/blog/healing-your-patterns.html
+++ b/blog/healing-your-patterns.html
@@ -1,6 +1,3 @@
----
-category: "Patterns & Psychology"
----
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8">
 <title>Healing Your Patterns: Breaking the Cycle | Seen & Red</title>
@@ -28,13 +25,6 @@ ul,ol{margin:10px 0 18px 22px}
 .ref li{margin-bottom:.45rem}
 .btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
 .btn:hover{background:var(--sr-red-soft)}
-/* Article-level category pill */
-.article-meta-pill{
-  display:inline-block;margin:.25rem 0 .8rem;padding:6px 10px;
-  font:700 .78rem/1 "Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-  text-transform:uppercase;letter-spacing:.02em;color:#fff;border-radius:999px
-}
-.article-meta-pill.category-psych{background:#6C63FF}
 #sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
 </style>
 <meta property="og:title" content="Healing Your Patterns: Breaking the Cycle">
@@ -44,11 +34,23 @@ ul,ol{margin:10px 0 18px 22px}
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Healing Your Patterns: Breaking the Cycle","datePublished":"2024-06-15","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Attachment, trauma bonds, and practical steps to change repeated relationship choices."}</script>
 </head><body>
 <main class="sr-article">
+<nav class="breadcrumb">
+  <a class="back-link" href="/blog/">← Back to Blog</a>
+  <span class="sep">·</span>
+  <a href="/blog/">Blog</a>
+  <span class="chev">›</span>
+  <a href="/blog/patterns-psychology/">Patterns &amp; Psychology</a>
+  <span class="chev">›</span>
+  <span class="current">Healing Your Patterns: Breaking the Cycle</span>
+</nav>
 <h1>Healing Your Patterns: Breaking the Cycle</h1>
-<div class="article-meta-pill category-psych">Patterns &amp; Psychology</div>
+<div class="article-badges">
+  <span class="badge badge-category">Patterns &amp; Psychology</span>
+</div>
 <p class="meta">Published: June 15, 2024 • ~10–12 min read</p>
 
 <p>We don’t only date with logic—we date with our nervous system. Attachment styles and trauma bonds can make chaos feel like chemistry. The goal isn’t to shame your past; it’s to understand the wiring so you can pick partners who match your <em>needs</em>, not your wounds.</p>

--- a/blog/ignoring-red-flags.html
+++ b/blog/ignoring-red-flags.html
@@ -1,6 +1,3 @@
----
-category: "Red Flags"
----
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8">
 <title>Ignoring Red Flags | Seen & Red</title>
@@ -23,13 +20,6 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 .ref li{margin-bottom:.45rem}
 .btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
 .btn:hover{background:var(--sr-red-soft)}
-/* Article-level category pill */
-.article-meta-pill{
-  display:inline-block;margin:.25rem 0 .8rem;padding:6px 10px;
-  font:700 .78rem/1 "Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-  text-transform:uppercase;letter-spacing:.02em;color:#fff;border-radius:999px
-}
-.article-meta-pill.category-red{background:#E63946}
 #sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
 </style>
 <meta property="og:title" content="Ignoring Red Flags">
@@ -39,11 +29,23 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Ignoring Red Flags","datePublished":"2024-08-08","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why we rationalize and how to act sooner with clear standards."}</script>
 </head><body>
 <main class="sr-article">
+<nav class="breadcrumb">
+  <a class="back-link" href="/blog/">← Back to Blog</a>
+  <span class="sep">·</span>
+  <a href="/blog/">Blog</a>
+  <span class="chev">›</span>
+  <a href="/blog/red-flags/">Red Flags</a>
+  <span class="chev">›</span>
+  <span class="current">Ignoring Red Flags</span>
+</nav>
 <h1>Ignoring Red Flags</h1>
-<div class="article-meta-pill category-red">Red Flag Radar</div>
+<div class="article-badges">
+  <span class="badge badge-category">Red Flags</span>
+</div>
 <p class="meta">Published: August 8, 2024 • ~8–10 min read</p>
 
 <p>Cognitive dissonance (Festinger) and sunk‑cost bias keep us attached to what we’ve already invested in. Hope can be beautiful — but in dating, hope without data becomes self‑gaslighting. Let’s face reality kindly and early.</p>

--- a/blog/missing-green-flags.html
+++ b/blog/missing-green-flags.html
@@ -1,6 +1,3 @@
----
-category: "Green Flags"
----
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8">
 <title>Missing Green Flags | Seen & Red</title>
@@ -23,13 +20,6 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 .ref li{margin-bottom:.45rem}
 .btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
 .btn:hover{background:var(--sr-red-soft)}
-/* Article-level category pill */
-.article-meta-pill{
-  display:inline-block;margin:.25rem 0 .8rem;padding:6px 10px;
-  font:700 .78rem/1 "Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-  text-transform:uppercase;letter-spacing:.02em;color:#fff;border-radius:999px
-}
-.article-meta-pill.category-green{background:#2ECC71}
 #sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
 </style>
 <meta property="og:title" content="Missing Green Flags">
@@ -39,11 +29,23 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Missing Green Flags","datePublished":"2024-07-30","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why negativity bias hides green flags and how to notice steady, reciprocal love."}</script>
 </head><body>
 <main class="sr-article">
+<nav class="breadcrumb">
+  <a class="back-link" href="/blog/">← Back to Blog</a>
+  <span class="sep">·</span>
+  <a href="/blog/">Blog</a>
+  <span class="chev">›</span>
+  <a href="/blog/green-flags/">Green Flags</a>
+  <span class="chev">›</span>
+  <span class="current">Missing Green Flags</span>
+</nav>
 <h1>Missing Green Flags</h1>
-<div class="article-meta-pill category-green">Green Flags</div>
+<div class="article-badges">
+  <span class="badge badge-category">Green Flags</span>
+</div>
 <p class="meta">Published: July 30, 2024 • ~8–10 min read</p>
 
 <p>When chaos feels like chemistry, steady can feel “too easy.” That’s negativity bias at work—your brain is wired to scan for threats, not tenderness. Let’s train your attention to notice what’s actually good for you.</p>

--- a/blog/red-vs-green-texts.html
+++ b/blog/red-vs-green-texts.html
@@ -1,6 +1,3 @@
----
-category: "Patterns & Psychology"
----
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8">
 <title>Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs | Seen & Red</title>
@@ -31,13 +28,6 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 .btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
 .btn:hover{background:var(--sr-red-soft)}
 .ref li{margin-bottom:.45rem}
-/* Article-level category pill */
-.article-meta-pill{
-  display:inline-block;margin:.25rem 0 .8rem;padding:6px 10px;
-  font:700 .78rem/1 "Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-  text-transform:uppercase;letter-spacing:.02em;color:#fff;border-radius:999px
-}
-.article-meta-pill.category-psych{background:#6C63FF}
 #sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
 </style>
 <meta property="og:title" content="Red Flag Texts vs. Green Flag Texts">
@@ -47,11 +37,23 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs","datePublished":"2025-08-22","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"15 texting examples with psychological explanations."}</script>
 </head><body>
 <main class="sr-article">
+<nav class="breadcrumb">
+  <a class="back-link" href="/blog/">← Back to Blog</a>
+  <span class="sep">·</span>
+  <a href="/blog/">Blog</a>
+  <span class="chev">›</span>
+  <a href="/blog/red-flags/">Red Flags</a>
+  <span class="chev">›</span>
+  <span class="current">Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs</span>
+</nav>
 <h1>Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs</h1>
-<div class="article-meta-pill category-psych">Patterns &amp; Psychology</div>
+<div class="article-badges">
+  <span class="badge badge-category">Red Flags</span>
+</div>
 <p class="meta">Published: August 22, 2025 • ~10–12 min read</p>
 
 <p>Receipts matter — but context matters more. Use these side‑by‑side examples to train your eye, then look for <em>patterns</em>, not one‑offs.</p>

--- a/blog/trust-your-intuition.html
+++ b/blog/trust-your-intuition.html
@@ -1,6 +1,3 @@
----
-category: "Patterns & Psychology"
----
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8">
 <title>Trust Your Intuition | Seen & Red</title>
@@ -23,13 +20,6 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 .ref li{margin-bottom:.45rem}
 .btn{display:inline-block;background:var(--sr-red);color:#fff;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;margin-right:10px}
 .btn:hover{background:var(--sr-red-soft)}
-/* Article-level category pill */
-.article-meta-pill{
-  display:inline-block;margin:.25rem 0 .8rem;padding:6px 10px;
-  font:700 .78rem/1 "Lato",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-  text-transform:uppercase;letter-spacing:.02em;color:#fff;border-radius:999px
-}
-.article-meta-pill.category-psych{background:#6C63FF}
 #sr-build{position:fixed;right:12px;bottom:12px;background:#1A1A1A;color:#fff;border-radius:999px;padding:6px 10px;font:600 12px/1 Lato,system-ui}
 </style>
 <meta property="og:title" content="Trust Your Intuition">
@@ -39,11 +29,23 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Trust Your Intuition","datePublished":"2024-07-10","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"A 4‑step gut check to separate intuition from anxiety, with examples."}</script>
 </head><body>
 <main class="sr-article">
+<nav class="breadcrumb">
+  <a class="back-link" href="/blog/">← Back to Blog</a>
+  <span class="sep">·</span>
+  <a href="/blog/">Blog</a>
+  <span class="chev">›</span>
+  <a href="/blog/patterns-psychology/">Patterns &amp; Psychology</a>
+  <span class="chev">›</span>
+  <span class="current">Trust Your Intuition</span>
+</nav>
 <h1>Trust Your Intuition</h1>
-<div class="article-meta-pill category-psych">Patterns &amp; Psychology</div>
+<div class="article-badges">
+  <span class="badge badge-category">Patterns &amp; Psychology</span>
+</div>
 <p class="meta">Published: July 10, 2024 • ~8–10 min read</p>
 
 <p>Your gut can be wise—and it can also be wired by past pain. Intuition is fast pattern‑recognition; anxiety is threat‑detection stuck in overdrive. Here’s how to tell which voice you’re hearing.</p>


### PR DESCRIPTION
## Summary
- remove leftover front-matter and add breadcrumb navigation with back link on article pages
- show category badges under each article title and tighten typography spacing via new CSS
- link to shared stylesheet to keep SEO head tags untouched

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a956dbbe288326b9d3afb1b39495cc