### PR TITLE
Clean up front‑matter remnants and tighten top spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -317,3 +317,13 @@ h1 { margin-top: 8px; margin-bottom: 8px; }
 article p { margin: 14px 0; }
 article h2 { margin: 28px 0 12px; }
 .callout, .note, .tip { background:#f7f7f8; border:1px solid #ececec; padding:16px 20px; border-radius:12px; }
+
+/* Tighten top whitespace for article pages */
+main, .article-container, .content {
+  padding-top: 16px !important;
+  margin-top: 0 !important;
+}
+header.site-header + main, .site-hero + main {
+  margin-top: 0 !important;
+}
+.breadcrumb { margin-top: 8px !important; }

--- a/blog/crowdsourced-dating-safety-facebook-tea-app.html
+++ b/blog/crowdsourced-dating-safety-facebook-tea-app.html
@@ -1,6 +1,3 @@
----
-category: "Dating Culture"
----
 <!doctype html>
 <html lang="en">
 <head>
@@ -14,6 +11,7 @@ category: "Dating Culture"
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/assets/css/styles.css" />
 
   <!-- Inline, namespaced styles (brand) -->
   <style>


### PR DESCRIPTION
## Summary
- remove stray front‑matter text from Crowdsourced Dating Safety article and link shared stylesheet
- tighten top whitespace on article pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a95a0e0ad883269cabcd3c3aa63dde