### PR TITLE
Add breadcrumb navigation and JSON-LD to blog pages

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -302,12 +302,6 @@ html, body { margin:0; }
 
 /* Article layout tightening */
 .content, main article, .article-container { max-width: 760px; margin: 0 auto; }
-.breadcrumb { font-size: 14px; color: #6b7280; margin: 16px 0 8px; }
-.breadcrumb a { color: inherit; text-decoration: none; }
-.breadcrumb a:hover { text-decoration: underline; }
-.breadcrumb .sep { margin: 0 8px; opacity: .6; }
-.breadcrumb .chev { margin: 0 6px; opacity: .6; }
-.back-link { margin-right: 8px; text-decoration: none; }
 
 h1 { margin-top: 8px; margin-bottom: 8px; }
 .article-badges { margin: 6px 0 14px; }
@@ -317,3 +311,12 @@ h1 { margin-top: 8px; margin-bottom: 8px; }
 article p { margin: 14px 0; }
 article h2 { margin: 28px 0 12px; }
 .callout, .note, .tip { background:#f7f7f8; border:1px solid #ececec; padding:16px 20px; border-radius:12px; }
+
+/* Breadcrumbs */
+.breadcrumb{font-size:14px;color:#6b7280;margin:12px 0 8px;display:flex;flex-wrap:wrap;align-items:center;gap:6px}
+.breadcrumb a{color:inherit;text-decoration:none}
+.breadcrumb a:hover{text-decoration:underline}
+.breadcrumb .sep,.breadcrumb .chev{opacity:.6}
+.back-link{margin-right:6px}
+.current{font-weight:600;color:#374151}
+@media (max-width:640px){.breadcrumb{font-size:13px}}

--- a/blog/crowdsourced-dating-safety-facebook-tea-app.html
+++ b/blog/crowdsourced-dating-safety-facebook-tea-app.html
@@ -1,6 +1,3 @@
----
-category: "Dating Culture"
----
 <!doctype html>
 <html lang="en">
 <head>
@@ -14,6 +11,8 @@ category: "Dating Culture"
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="/assets/css/styles.css" />
 
   <!-- Inline, namespaced styles (brand) -->
   <style>
@@ -53,9 +52,32 @@ category: "Dating Culture"
     "description":"A calm, practical guide to using Facebook dating‑safety groups and the Tea app wisely."
   }
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+      { "@type": "ListItem", "position": 3, "name": "Dating Culture", "item": "https://seenandred.com/blog/dating-culture/" },
+      { "@type": "ListItem", "position": 4, "name": "Crowdsourced Dating Safety: Facebook Groups & Tea App — How to Vet Receipts (Without the Drama)", "item": "https://seenandred.com/blog/crowdsourced-dating-safety-facebook-tea-app.html" }
+    ]
+  }
+  </script>
 </head>
 <body>
   <main class="sr-article">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
+      <span class="sep">·</span>
+      <a href="/">Home</a>
+      <span class="chev">›</span>
+      <a href="/blog/">Blog</a>
+      <span class="chev">›</span>
+      <a href="/blog/dating-culture/">Dating Culture</a>
+      <span class="chev">›</span>
+      <span class="current" aria-current="page">Crowdsourced Dating Safety: Facebook Groups &amp; Tea App — How to Vet Receipts (Without the Drama)</span>
+    </nav>
     <h1>Crowdsourced Dating Safety: Facebook Groups &amp; Tea App — How to Vet Receipts (Without the Drama)</h1>
     <p class="meta">Published: May 12, 2024 • ~6 min read</p>
 

--- a/blog/dating-culture/index.html
+++ b/blog/dating-culture/index.html
@@ -6,6 +6,7 @@
 <link rel="canonical" href="https://seenandred.com/blog/dating-culture/">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <style>
 :root{--sr-coral:#FF6B6B;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
 html,body{margin:0;background:#fff;color:var(--sr-ink)}
@@ -51,8 +52,28 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 }
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Dating Culture", "item": "https://seenandred.com/blog/dating-culture/" }
+  ]
+}
+</script>
 </head><body>
 <main>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
+    <span class="sep">·</span>
+    <a href="/">Home</a>
+    <span class="chev">›</span>
+    <a href="/blog/">Blog</a>
+    <span class="chev">›</span>
+    <span class="current" aria-current="page">Dating Culture</span>
+  </nav>
   <div class="hero">
     <span class="kicker">Dating Culture</span>
     <h1>Social Media & Crowd Intel: Using the Feed Without Losing Your Mind</h1>

--- a/blog/dating-in-the-era-of-social-media.html
+++ b/blog/dating-in-the-era-of-social-media.html
@@ -31,16 +31,30 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Dating in the Era of Social Media","datePublished":"2025-08-20","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Boundaries that work, red/green DM examples, and how to use group intel without drama."}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Dating Culture", "item": "https://seenandred.com/blog/dating-culture/" },
+    { "@type": "ListItem", "position": 4, "name": "Dating in the Era of Social Media: How Likes, DMs & Group Chats Rewrite the Rules", "item": "https://seenandred.com/blog/dating-in-the-era-of-social-media.html" }
+  ]
+}
+</script>
 </head><body>
 <main class="sr-article">
-<nav class="breadcrumb">
-  <a class="back-link" href="/blog/">← Back to Blog</a>
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
   <span class="sep">·</span>
+  <a href="/">Home</a>
+  <span class="chev">›</span>
   <a href="/blog/">Blog</a>
   <span class="chev">›</span>
   <a href="/blog/dating-culture/">Dating Culture</a>
   <span class="chev">›</span>
-  <span class="current">Dating in the Era of Social Media: How Likes, DMs &amp; Group Chats Rewrite the Rules</span>
+  <span class="current" aria-current="page">Dating in the Era of Social Media: How Likes, DMs &amp; Group Chats Rewrite the Rules</span>
 </nav>
 <h1>Dating in the Era of Social Media: How Likes, DMs &amp; Group Chats Rewrite the Rules</h1>
 <div class="article-badges">

--- a/blog/green-flags/index.html
+++ b/blog/green-flags/index.html
@@ -6,6 +6,7 @@
 <link rel="canonical" href="https://seenandred.com/blog/green-flags/">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <style>
 :root{--sr-green:#2ECC71;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
 html,body{margin:0;background:#fff;color:var(--sr-ink)}
@@ -51,8 +52,28 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 }
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Green Flags", "item": "https://seenandred.com/blog/green-flags/" }
+  ]
+}
+</script>
 </head><body>
 <main>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
+    <span class="sep">·</span>
+    <a href="/">Home</a>
+    <span class="chev">›</span>
+    <a href="/blog/">Blog</a>
+    <span class="chev">›</span>
+    <span class="current" aria-current="page">Green Flags</span>
+  </nav>
   <div class="hero">
     <span class="kicker">Green Flags</span>
     <h1>Green Flags: The Small Signs That Predict Real Love</h1>

--- a/blog/healing-your-patterns.html
+++ b/blog/healing-your-patterns.html
@@ -36,16 +36,30 @@ ul,ol{margin:10px 0 18px 22px}
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Healing Your Patterns: Breaking the Cycle","datePublished":"2024-06-15","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Attachment, trauma bonds, and practical steps to change repeated relationship choices."}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Patterns & Psychology", "item": "https://seenandred.com/blog/patterns-psychology/" },
+    { "@type": "ListItem", "position": 4, "name": "Healing Your Patterns: Breaking the Cycle", "item": "https://seenandred.com/blog/healing-your-patterns.html" }
+  ]
+}
+</script>
 </head><body>
 <main class="sr-article">
-<nav class="breadcrumb">
-  <a class="back-link" href="/blog/">← Back to Blog</a>
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
   <span class="sep">·</span>
+  <a href="/">Home</a>
+  <span class="chev">›</span>
   <a href="/blog/">Blog</a>
   <span class="chev">›</span>
   <a href="/blog/patterns-psychology/">Patterns &amp; Psychology</a>
   <span class="chev">›</span>
-  <span class="current">Healing Your Patterns: Breaking the Cycle</span>
+  <span class="current" aria-current="page">Healing Your Patterns: Breaking the Cycle</span>
 </nav>
 <h1>Healing Your Patterns: Breaking the Cycle</h1>
 <div class="article-badges">

--- a/blog/ignoring-red-flags.html
+++ b/blog/ignoring-red-flags.html
@@ -31,16 +31,30 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Ignoring Red Flags","datePublished":"2024-08-08","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why we rationalize and how to act sooner with clear standards."}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Red Flags", "item": "https://seenandred.com/blog/red-flags/" },
+    { "@type": "ListItem", "position": 4, "name": "Ignoring Red Flags", "item": "https://seenandred.com/blog/ignoring-red-flags.html" }
+  ]
+}
+</script>
 </head><body>
 <main class="sr-article">
-<nav class="breadcrumb">
-  <a class="back-link" href="/blog/">← Back to Blog</a>
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
   <span class="sep">·</span>
+  <a href="/">Home</a>
+  <span class="chev">›</span>
   <a href="/blog/">Blog</a>
   <span class="chev">›</span>
   <a href="/blog/red-flags/">Red Flags</a>
   <span class="chev">›</span>
-  <span class="current">Ignoring Red Flags</span>
+  <span class="current" aria-current="page">Ignoring Red Flags</span>
 </nav>
 <h1>Ignoring Red Flags</h1>
 <div class="article-badges">

--- a/blog/index.html
+++ b/blog/index.html
@@ -90,10 +90,26 @@ html,body{margin:0}
 
   </style>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Seen & Red Blog","description":"Seen & Red blog covering modern dating, boundaries, and relationship clarity.","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"mainEntityOfPage":"https://seenandred.com/blog/"}</script>
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"}]}</script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" }
+    ]
+  }
+  </script>
 </head>
 <body>
 <div class="sr-container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a class="back-link" href="/" aria-label="Back to Home">← Back to Home</a>
+    <span class="sep">·</span>
+    <a href="/">Home</a>
+    <span class="chev">›</span>
+    <span class="current" aria-current="page">Blog</span>
+  </nav>
   <h1 class="sr-page-title">Blog</h1>
   <p class="sr-page-sub">Research‑backed clarity for modern dating.</p>
 

--- a/blog/missing-green-flags.html
+++ b/blog/missing-green-flags.html
@@ -31,16 +31,30 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Missing Green Flags","datePublished":"2024-07-30","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Why negativity bias hides green flags and how to notice steady, reciprocal love."}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Green Flags", "item": "https://seenandred.com/blog/green-flags/" },
+    { "@type": "ListItem", "position": 4, "name": "Missing Green Flags", "item": "https://seenandred.com/blog/missing-green-flags.html" }
+  ]
+}
+</script>
 </head><body>
 <main class="sr-article">
-<nav class="breadcrumb">
-  <a class="back-link" href="/blog/">← Back to Blog</a>
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
   <span class="sep">·</span>
+  <a href="/">Home</a>
+  <span class="chev">›</span>
   <a href="/blog/">Blog</a>
   <span class="chev">›</span>
   <a href="/blog/green-flags/">Green Flags</a>
   <span class="chev">›</span>
-  <span class="current">Missing Green Flags</span>
+  <span class="current" aria-current="page">Missing Green Flags</span>
 </nav>
 <h1>Missing Green Flags</h1>
 <div class="article-badges">

--- a/blog/patterns-psychology/index.html
+++ b/blog/patterns-psychology/index.html
@@ -6,6 +6,7 @@
 <link rel="canonical" href="https://seenandred.com/blog/patterns-psychology/">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <style>
 :root{--sr-violet:#6C63FF;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
 html,body{margin:0;background:#fff;color:var(--sr-ink)}
@@ -54,8 +55,28 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 }
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Patterns & Psychology", "item": "https://seenandred.com/blog/patterns-psychology/" }
+  ]
+}
+</script>
 </head><body>
 <main>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
+    <span class="sep">·</span>
+    <a href="/">Home</a>
+    <span class="chev">›</span>
+    <a href="/blog/">Blog</a>
+    <span class="chev">›</span>
+    <span class="current" aria-current="page">Patterns &amp; Psychology</span>
+  </nav>
   <div class="hero">
     <span class="kicker">Patterns &amp; Psychology</span>
     <h1>Attachment, Intuition &amp; Receipts: The Science of Better Choices</h1>

--- a/blog/red-flags/index.html
+++ b/blog/red-flags/index.html
@@ -6,6 +6,7 @@
 <link rel="canonical" href="https://seenandred.com/blog/red-flags/">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/css/styles.css" />
 <style>
 :root{--sr-red:#E63946;--sr-ink:#1A1A1A;--sr-border:#EDEDED;--sr-muted:#666}
 html,body{margin:0;background:#fff;color:var(--sr-ink)}
@@ -51,8 +52,28 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 }
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Red Flags", "item": "https://seenandred.com/blog/red-flags/" }
+  ]
+}
+</script>
 </head><body>
 <main>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
+    <span class="sep">·</span>
+    <a href="/">Home</a>
+    <span class="chev">›</span>
+    <a href="/blog/">Blog</a>
+    <span class="chev">›</span>
+    <span class="current" aria-current="page">Red Flags</span>
+  </nav>
   <div class="hero">
     <span class="kicker">Red Flags</span>
     <h1>Dating Red Flags: See Them, Believe Them, Act Early</h1>

--- a/blog/red-vs-green-texts.html
+++ b/blog/red-vs-green-texts.html
@@ -39,16 +39,30 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs","datePublished":"2025-08-22","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"15 texting examples with psychological explanations."}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Red Flags", "item": "https://seenandred.com/blog/red-flags/" },
+    { "@type": "ListItem", "position": 4, "name": "Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs", "item": "https://seenandred.com/blog/red-vs-green-texts.html" }
+  ]
+}
+</script>
 </head><body>
 <main class="sr-article">
-<nav class="breadcrumb">
-  <a class="back-link" href="/blog/">← Back to Blog</a>
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
   <span class="sep">·</span>
+  <a href="/">Home</a>
+  <span class="chev">›</span>
   <a href="/blog/">Blog</a>
   <span class="chev">›</span>
   <a href="/blog/red-flags/">Red Flags</a>
   <span class="chev">›</span>
-  <span class="current">Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs</span>
+  <span class="current" aria-current="page">Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs</span>
 </nav>
 <h1>Red Flag Texts vs. Green Flag Texts: How to Spot the Difference in Your DMs</h1>
 <div class="article-badges">

--- a/blog/trust-your-intuition.html
+++ b/blog/trust-your-intuition.html
@@ -31,16 +31,30 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Trust Your Intuition","datePublished":"2024-07-10","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"A 4‑step gut check to separate intuition from anxiety, with examples."}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://seenandred.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://seenandred.com/blog/" },
+    { "@type": "ListItem", "position": 3, "name": "Patterns & Psychology", "item": "https://seenandred.com/blog/patterns-psychology/" },
+    { "@type": "ListItem", "position": 4, "name": "Trust Your Intuition", "item": "https://seenandred.com/blog/trust-your-intuition.html" }
+  ]
+}
+</script>
 </head><body>
 <main class="sr-article">
-<nav class="breadcrumb">
-  <a class="back-link" href="/blog/">← Back to Blog</a>
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a class="back-link" href="/blog/" aria-label="Back to Blog">← Back to Blog</a>
   <span class="sep">·</span>
+  <a href="/">Home</a>
+  <span class="chev">›</span>
   <a href="/blog/">Blog</a>
   <span class="chev">›</span>
   <a href="/blog/patterns-psychology/">Patterns &amp; Psychology</a>
   <span class="chev">›</span>
-  <span class="current">Trust Your Intuition</span>
+  <span class="current" aria-current="page">Trust Your Intuition</span>
 </nav>
 <h1>Trust Your Intuition</h1>
 <div class="article-badges">


### PR DESCRIPTION
## Summary
- add responsive breadcrumb nav and back links across blog, category, and article pages
- inject BreadcrumbList JSON-LD for SEO on all blog-related pages
- remove stray front matter remnants and consolidate styles in styles.css

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a95a11dcd48326afe2953f4504f040