### PR TITLE
Add Ghosted in the City article and update blog index for build v27

### DIFF
--- a/blog/ghosted-in-the-city.html
+++ b/blog/ghosted-in-the-city.html
@@ -6,10 +6,10 @@
   <meta name="description" content="Is it ghosting or just a busy week? Read the signs, see real text examples, and grab clear scripts that protect your peace." />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Lato:wght@400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="stylesheet" href="/styles.css" />
   <link rel="canonical" href="https://seenandred.com/blog/ghosted-in-the-city.html" />
 
-  <!-- Open Graph / Twitter (remote image; no binaries) -->
+  <!-- OG / Twitter (remote image) -->
   <meta property="og:type" content="article" />
   <meta property="og:title" content="Ghosted in the City: When Silence Speaks Louder Than Sex" />
   <meta property="og:description" content="Is it ghosting or just a busy week? Read the signs, see real text examples, and grab clear scripts that protect your peace." />
@@ -19,7 +19,7 @@
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
 
-  <!-- BlogPosting JSON-LD (binary-safe logo & image) -->
+  <!-- Schema: BlogPosting -->
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
@@ -41,8 +41,6 @@
 </head>
 <body>
 <main class="prose-wrap">
-
-  <!-- Optional hero (remote) -->
   <figure class="article-hero">
     <img src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=1600&h=900&fit=crop&q=80" alt="City night scene with a glowing phone" />
   </figure>
@@ -91,42 +89,23 @@
     <h2>Get Clarity (Without Overthinking)</h2>
     <p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message — Free</a></p>
     <p><a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
-
   </article>
 </main>
 
-<!-- Breadcrumbs (Schema) -->
+<!-- Breadcrumbs -->
 <script type="application/ld+json">
-{
-  "@context":"https://schema.org",
-  "@type":"BreadcrumbList",
-  "itemListElement":[
-    {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
-    {"@type":"ListItem","position":2,"name":"Dating Culture","item":"https://seenandred.com/blog/dating-culture/"},
-    {"@type":"ListItem","position":3,"name":"Ghosted in the City","item":"https://seenandred.com/blog/ghosted-in-the-city.html"}
-  ]
-}
+{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+  {"@type":"ListItem","position":1,"name":"Blog","item":"https://seenandred.com/blog/"},
+  {"@type":"ListItem","position":2,"name":"Dating Culture","item":"https://seenandred.com/blog/dating-culture/"},
+  {"@type":"ListItem","position":3,"name":"Ghosted in the City","item":"https://seenandred.com/blog/ghosted-in-the-city.html"}
+]}
 </script>
 
-<!-- Product schema for the monthly plan -->
+<!-- Product Schema -->
 <script type="application/ld+json">
-{
-  "@context":"https://schema.org",
-  "@type":"Product",
-  "name":"Unlimited Message Analysis",
-  "brand":"Seen & Red",
-  "description":"Unlimited message analysis for patterns, red/green flags, and boundary guidance.",
-  "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00",
-  "offers":{
-    "@type":"Offer",
-    "priceCurrency":"USD",
-    "price":"12.00",
-    "availability":"https://schema.org/InStock",
-    "url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
-  }
-}
+{"@context":"https://schema.org","@type":"Product","name":"Unlimited Message Analysis","brand":"Seen & Red","description":"Unlimited message analysis for patterns, red/green flags, and boundary guidance.","url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00","offers":{"@type":"Offer","priceCurrency":"USD","price":"12.00","availability":"https://schema.org/InStock","url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"}}
 </script>
 
-<div id="sr-build-badge" style="position:fixed;right:12px;bottom:12px;background:#111;color:#fff;border-radius:999px;padding:8px 12px;font:600 12px/1 Lato,sans-serif">Build v26</div>
+<div id="sr-build-badge" style="position:fixed;right:12px;bottom:12px;background:#111;color:#fff;border-radius:999px;padding:8px 12px;font:600 12px/1 Lato,sans-serif">Build v27</div>
 </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -124,16 +124,12 @@ html,body{margin:0}
 
   <section class="post-grid">
     <!-- Ghosted in the City — Dating Culture -->
-    <article class="post-card" data-category="culture" id="post-112">
-      <a class="post-link" href="/blog/ghosted-in-the-city.html" aria-label="Read: Ghosted in the City: When Silence Speaks Louder Than Sex">
-        <img class="post-thumb" src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="Phone with unread texts" loading="lazy">
-        <div class="post-body">
-          <div class="blog-meta category-culture">Dating Culture</div>
-          <h3 class="post-title">Ghosted in the City: When Silence Speaks Louder Than Sex</h3>
-          <p class="post-meta">Aug 22, 2025 • ~7 min read</p>
-          <p class="post-excerpt">Is it ghosting or just a busy week? Read the receipts before you spiral.</p>
-        </div>
-      </a>
+    <article class="post-card" data-category="culture" id="post-ghosted-city">
+      <img class="thumb" src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="Phone with unread texts" loading="lazy" />
+      <div class="blog-meta category-culture">Dating Culture</div>
+      <h2 class="blog-title"><a href="/blog/ghosted-in-the-city.html">Ghosted in the City: When Silence Speaks Louder Than Sex</a></h2>
+      <p class="blog-date">Aug 22, 2025 • ~7 min read</p>
+      <p class="blog-snippet">Is it ghosting or just a busy week? Read the receipts before you spiral.</p>
     </article>
 
     <!-- Social Media — Dating Culture -->
@@ -238,7 +234,7 @@ html,body{margin:0}
   </div>
 </div>
 
-  <div id="sr-build-badge">Seen &amp; Red • Blog Build v26</div>
+  <div id="sr-build-badge">Seen &amp; Red • Blog Build v27</div>
 
 <script>
 (function(){

--- a/blog/sitemap.xml
+++ b/blog/sitemap.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://seenandred.com/blog/ghosted-in-the-city.html</loc></url>
+  <url><loc>https://seenandred.com/blog/ghosted-in-the-city.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add full Ghosted in the City article page with remote images and schema
- insert Ghosted in the City card on blog index and bump build badge to v27
- append Ghosted in the City URL to blog sitemap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9cf13031c8326a9d59f3d5d53670f