### PR TITLE
Add blog grid card layout and hero image styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -342,3 +342,72 @@ nav ul {
   font:600 12px/1 Lato, sans-serif; box-shadow: var(--sr-shadow);
   z-index: 50;
 }
+
+/* (your existing styles remain above) */
+
+/* ===== Blog grid & cards (uniform layout) ===== */
+.blog-grid {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.blog-card {
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.06);
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.blog-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0,0,0,0.10);
+}
+.blog-card .card-link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+.blog-card .card-img {
+  width: 100%;
+  height: 180px;           /* adjust to 200–240px if you want taller thumbs */
+  object-fit: cover;       /* crop instead of stretch */
+  display: block;
+}
+.blog-card .card-body {
+  padding: 14px 16px 18px;
+}
+.blog-card h2 {
+  font-size: 1.125rem;
+  line-height: 1.35;
+  margin: 0 0 8px;
+}
+.blog-card p {
+  margin: 0;
+  color: #555;
+  font-size: 0.98rem;
+}
+@media (min-width: 1200px) {
+  .blog-grid { grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); }
+}
+.blog-card a:link,
+.blog-card a:visited { text-decoration: none; color: inherit; }
+.blog-card a:hover { text-decoration: none; }
+
+/* ===== Article hero image ===== */
+.hero-image img {
+  width: 100%;
+  max-height: 420px;
+  object-fit: cover;
+  display: block;
+  border-radius: 12px;
+}
+.hero-image figcaption {
+  font-size: 0.95rem;
+  color: #666;
+  margin-top: 8px;
+}
+


### PR DESCRIPTION
## Summary
- add responsive blog grid layout and card styling
- style article hero images with capped height and captions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09a71ff4c8326b6525a1a8b4fc1f6