### PR TITLE
Add hero buttons to landing page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -83,6 +83,47 @@ a:hover, a:focus { color: var(--sr-red-soft); }
 }
 .sr-btn:hover { background: var(--sr-red-soft); transform: translateY(-1px); }
 
+/* Hero buttons */
+.hero-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 12px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: var(--sr-shadow);
+  transition: transform .08s ease, background .2s ease, color .2s ease;
+}
+
+.btn-primary {
+  background: var(--sr-red);
+  color: #fff;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--sr-red);
+  border: 2px solid var(--sr-red);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn-primary:hover {
+  background: var(--sr-red-soft);
+}
+
+.btn-secondary:hover {
+  background: var(--sr-red-soft);
+  color: #fff;
+}
+
 /* === Blog Index Card === */
 .post-card {
   background: #fff;

--- a/index.html
+++ b/index.html
@@ -598,10 +598,10 @@
   <div class="sr-hero-content">
     <h1 class="sr-hero-title">Seen &amp; Red</h1>
     <p class="sr-hero-sub">Research-backed clarity for modern dating.</p>
-    <p>
-      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener" aria-label="Decode a Message (free analysis)">Decode a Message</a>
-      <a class="sr-btn" href="/blog/">Read the Blog</a>
-    </p>
+    <div class="hero-buttons">
+      <a href="/analyze" class="btn btn-primary">Get Your Free Analysis</a>
+      <a href="/blog" class="btn btn-secondary">Read the Blog</a>
+    </div>
   </div>
 </section>
         <section id="analysis" class="analysis-section">


### PR DESCRIPTION
## Summary
- Replace single hero CTA with pair of "Get Your Free Analysis" and "Read the Blog" buttons
- Introduce `.hero-buttons` wrapper and shared `.btn` styles with primary/secondary variants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0cf0a6f7483269799b21cfdfa9ce5