### PR TITLE
fix: point Free Analysis CTA and nav Analyze to JotForm URL with secure new-tab behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,7 +578,13 @@
 <nav class="site-nav" aria-label="Main">
   <ul class="nav-list">
     <li><a href="/">Home</a></li>
-    <li><a href="/analyze">Analyze</a></li>
+    <li>
+      <a href="https://form.jotform.com/252205735289057"
+         target="_blank"
+         rel="noopener noreferrer">
+        Analyze
+      </a>
+    </li>
     <li><a href="/blog">Blog</a></li>
     <li><a href="/about">About</a></li>
     <li><a href="/unlimited">Go Unlimited — Reality Check</a></li>
@@ -597,8 +603,10 @@
     <p class="sr-hero-sub">Research-backed clarity for modern dating.</p>
     <div class="hero-buttons" role="group" aria-label="Primary actions">
       <!-- Primary CTA -->
-      <a href="/analyze"
+      <a href="https://form.jotform.com/252205735289057"
          class="btn btn-primary"
+         target="_blank"
+         rel="noopener noreferrer"
          aria-label="Get your free analysis">
         Get Your Free Analysis
       </a>


### PR DESCRIPTION
## Summary
- Point top-nav "Analyze" and hero "Get Your Free Analysis" CTA to JotForm form in new tab with security attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1048261dc83269d3d6301d6c1086b