### PR TITLE
fix: restore payment CTA to PCI JotForm and preserve Free Analysis link targets

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,13 +581,21 @@
     <li>
       <a href="https://form.jotform.com/252205735289057"
          target="_blank"
-         rel="noopener noreferrer">
+         rel="noopener noreferrer"
+         data-analytics="cta-free-analysis">
         Analyze
       </a>
     </li>
     <li><a href="/blog">Blog</a></li>
     <li><a href="/about">About</a></li>
-    <li><a href="/unlimited">Go Unlimited — Reality Check</a></li>
+    <li>
+      <a href="https://pci.jotform.com/form/252205842827054"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-analytics="cta-unlimited">
+        Go Unlimited — Reality Check
+      </a>
+    </li>
   </ul>
 </nav>
 
@@ -607,7 +615,8 @@
          class="btn btn-primary"
          target="_blank"
          rel="noopener noreferrer"
-         aria-label="Get your free analysis">
+         aria-label="Get your free analysis"
+         data-analytics="cta-free-analysis">
         Get Your Free Analysis
       </a>
 
@@ -642,7 +651,11 @@
                                 <li>Priority Support</li>
                                 <li>Cancel Anytime (but you won't want to)</li>
                             </ul>
-                            <a href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" class="pricing-button" target="_blank" rel="nofollow noopener">Get Unlimited Analysis</a>
+                            <a href="https://pci.jotform.com/form/252205842827054"
+                               class="pricing-button"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               data-analytics="cta-unlimited">Get Unlimited Analysis</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- point navbar "Go Unlimited — Reality Check" to the PCI JotForm with secure attributes and analytics tag
- update the pricing section button to the same PCI JotForm and open in a new tab
- tag Free Analysis CTAs with analytics identifiers

## Testing
- `npm test`
- `rg '/unlimited' -n || true`


------
https://chatgpt.com/codex/tasks/task_e_68b1072221488326885e160a8d9298e3