### PR TITLE
Use local hero image for Ghosted article

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -338,6 +338,27 @@ html, body { margin:0; }
   font-size: 22px; color: var(--sr-red);
 }
 
+/* Ghosted blog card image */
+.blog-card-img{
+  display: block;
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 14px;
+  margin-bottom: 10px;
+}
+
+/* Ghosted post hero image */
+.post-hero-img{
+  display: block;
+  width: 100%;
+  height: clamp(180px, 38vw, 420px);
+  object-fit: cover;
+  border-radius: var(--sr-radius);
+  box-shadow: var(--sr-shadow);
+  margin: 0 0 14px;
+}
+
 /* Content */
 .post-body{ padding: 16px 16px 18px; }
 

--- a/blog/ghosted-in-the-city.html
+++ b/blog/ghosted-in-the-city.html
@@ -41,9 +41,11 @@
 </head>
 <body>
 <main class="prose-wrap">
-  <figure class="article-hero">
-    <img src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=1600&h=900&fit=crop&q=80" alt="City night scene with a glowing phone" />
-  </figure>
+  <img
+    src="/assets/images/blog/ghosted-hero.jpg"
+    alt="Moody urban night scene with a glowing phone symbolizing ghosting"
+    class="post-hero-img"
+  />
 
   <article class="prose">
     <h1>Ghosted in the City: When Silence Speaks Louder Than Sex</h1>

--- a/blog/index.html
+++ b/blog/index.html
@@ -149,7 +149,11 @@ html,body{margin:0}
 
     <!-- Ghosted in the City — Dating Culture -->
     <article class="post-card" data-category="culture" id="post-ghosted-city">
-      <img class="thumb" src="https://images.unsplash.com/photo-1512389142860-9c449e58a543?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" />
+      <img
+        src="/assets/images/blog/ghosted-hero.jpg"
+        alt="Moody urban night scene with a glowing phone symbolizing ghosting"
+        class="blog-card-img"
+      />
       <div class="blog-meta category-culture">Dating Culture</div>
       <h2 class="blog-title"><a href="/blog/ghosted-in-the-city.html">Ghosted in the City: When Silence Speaks Louder Than Sex</a></h2>
       <p class="blog-date">Aug 22, 2025 • ~7 min read</p>


### PR DESCRIPTION
## Summary
- Use the dedicated ghosted hero image on the blog index card.
- Display the same hero image at the top of the Ghosted article.
- Add styling for blog card and post hero images.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b14183ebb08326a6e4239b3ad7582d