### PR TITLE
fix(blog): correct CTA targets across posts

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -56,7 +56,7 @@ html,body{margin:0}
                 <nav>
                     <ul>
                         <li><a href="index.html">Home</a></li>
-                        <li><a href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze</a></li>
+                        <li><a href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="about.html">About</a></li>
                     </ul>
@@ -176,8 +176,8 @@ html,body{margin:0}
   <div class="sr-cta">
     <p class="sr-cta-text"><strong>Want clarity on your own messages?</strong></p>
     <div>
-      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-      <a class="sr-btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+      <a class="sr-btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a>
     </div>
   </div>
 </div>

--- a/blog/crowdsourced-dating-safety-facebook-tea-app.html
+++ b/blog/crowdsourced-dating-safety-facebook-tea-app.html
@@ -100,8 +100,8 @@
 
     <hr>
     <p>
-      <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-      <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+      <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+      <a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a>
     </p>
     <p><em>Need a second set of eyes on a DM or post? Drop it in—get a balanced, evidence‑based read without the pile‑on.</em></p>
   </main>

--- a/blog/dating-culture/index.html
+++ b/blog/dating-culture/index.html
@@ -137,8 +137,8 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   </section>
 
   <div class="footer-cta">
-    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+    <a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
 <div id="sr-build">Build v26</div>

--- a/blog/dating-in-the-era-of-social-media.html
+++ b/blog/dating-in-the-era-of-social-media.html
@@ -107,8 +107,8 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 </section>
 
 <hr>
-<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+<a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a></p>
 <p><em>Crowdsourced intel helps — personalized clarity keeps you sane. Unlimited lets you decode your actual threads.</em></p>
 </main>
 

--- a/blog/ghosted-in-the-city.html
+++ b/blog/ghosted-in-the-city.html
@@ -88,8 +88,8 @@
 
     <hr />
     <h2>Get Clarity (Without Overthinking)</h2>
-    <p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message — Free</a></p>
-    <p><a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+    <p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message — Free</a></p>
+    <p><a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a></p>
   </article>
 </main>
 
@@ -104,7 +104,7 @@
 
 <!-- Product Schema -->
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"Product","name":"Unlimited Message Analysis","brand":"Seen & Red","description":"Unlimited message analysis for patterns, red/green flags, and boundary guidance.","url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00","offers":{"@type":"Offer","priceCurrency":"USD","price":"12.00","availability":"https://schema.org/InStock","url":"https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"}}
+{"@context":"https://schema.org","@type":"Product","name":"Unlimited Message Analysis","brand":"Seen & Red","description":"Unlimited message analysis for patterns, red/green flags, and boundary guidance.","url":"https://pci.jotform.com/form/252205842827054","offers":{"@type":"Offer","priceCurrency":"USD","price":"12.00","availability":"https://schema.org/InStock","url":"https://pci.jotform.com/form/252205842827054"}}
 </script>
 
 <div id="sr-build-badge" style="position:fixed;right:12px;bottom:12px;background:#111;color:#fff;border-radius:999px;padding:8px 12px;font:600 12px/1 Lato,sans-serif">Build v27</div>

--- a/blog/green-flags/index.html
+++ b/blog/green-flags/index.html
@@ -99,8 +99,8 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   </section>
 
   <div class="footer-cta">
-    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+    <a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
 <div id="sr-build">Build v26</div>

--- a/blog/healing-your-patterns.html
+++ b/blog/healing-your-patterns.html
@@ -125,8 +125,8 @@
 </section>
 
 <hr>
-<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+<a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a></p>
 <p><em>One text is a moment. A thread is a pattern. Unlimited helps you see the truth over time.</em></p>
   </article>
 </main>

--- a/blog/ignoring-red-flags.html
+++ b/blog/ignoring-red-flags.html
@@ -95,8 +95,8 @@
 </section>
 
 <hr>
-<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+<a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a></p>
 <p><em>Red flags hide in repetition. Unlimited lets you decode not just “one weird text,” but the trend.</em></p>
   </article>
 </main>

--- a/blog/index.html
+++ b/blog/index.html
@@ -256,8 +256,8 @@ html,body{margin:0}
   <div class="sr-cta">
     <p class="sr-cta-text"><strong>Want clarity on your own messages?</strong></p>
     <div>
-      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-      <a class="sr-btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+      <a class="sr-btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+      <a class="sr-btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a>
     </div>
   </div>
 </div>

--- a/blog/missing-green-flags.html
+++ b/blog/missing-green-flags.html
@@ -102,8 +102,8 @@
 </section>
 
 <hr>
-<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+<a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a></p>
 <p><em>Red flags scream. Green flags whisper. Unlimited helps you hear both across the whole thread.</em></p>
   </article>
 </main>

--- a/blog/patterns-psychology/index.html
+++ b/blog/patterns-psychology/index.html
@@ -110,8 +110,8 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   </section>
 
   <div class="footer-cta">
-    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+    <a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
 <div id="sr-build">Build v26</div>

--- a/blog/red-flags/index.html
+++ b/blog/red-flags/index.html
@@ -99,8 +99,8 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
   </section>
 
   <div class="footer-cta">
-    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-    <a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a>
+    <a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+    <a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a>
   </div>
 </main>
 <div id="sr-build">Build v26</div>

--- a/blog/red-vs-green-texts.html
+++ b/blog/red-vs-green-texts.html
@@ -126,8 +126,8 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 </section>
 
 <hr>
-<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+<a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a></p>
 <p><em>Unlimited helps you decode <strong>patterns</strong> — not just one line.</em></p>
 </main>
 

--- a/blog/trust-your-intuition.html
+++ b/blog/trust-your-intuition.html
@@ -103,8 +103,8 @@
 </section>
 
 <hr>
-<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Analyze a Message (free)</a>
-<a class="btn" href="https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00" target="_blank" rel="noopener">Unlimited Analysis — $12/mo</a></p>
+<p><a class="btn" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Analyze a Message (free)</a>
+<a class="btn" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Unlimited Analysis — $12/mo</a></p>
 <p><em>Your gut reacts to one text. Truth shows up across threads. Unlimited helps you see the signal, not just the spike.</em></p>
   </article>
 </main>

--- a/config/site.json
+++ b/config/site.json
@@ -1,3 +1,4 @@
 {
-  "STRIPE_UNLIMITED_URL": "https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00"
+  "FREE_ANALYSIS_URL": "https://form.jotform.com/252205735289057",
+  "UNLIMITED_CTA_URL": "https://pci.jotform.com/form/252205842827054"
 }


### PR DESCRIPTION
## Summary
- direct free CTA buttons to JotForm with noopener/noreferrer and analytics tags
- route paid upgrade CTAs to PCI JotForm endpoint and track via `data-analytics="cta-unlimited"`
- centralize CTA URLs in config for future reuse

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1479226248326b59d50062bd2b164