### PR TITLE
Add CTA redirect pages and update blog links

### DIFF
--- a/blog/dating-in-your-20s-the-swipe-decade.html
+++ b/blog/dating-in-your-20s-the-swipe-decade.html
@@ -97,8 +97,8 @@
       <h2>Ready to Decode Your Relationship Patterns?</h2>
       <p class="cta-sub">Start with a free analysis, then go deeper when you’re ready.</p>
       <div class="cta-group">
-        <a class="btn btn-primary" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Get a Free Analysis</a>
-        <a class="btn btn-accent" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Upgrade to Paid Decode</a>
+        <a class="btn btn-primary" href="/go/free-analysis/" rel="noopener">Get a Free Analysis</a>
+        <a class="btn btn-accent" href="/go/paid-decode/" rel="noopener">Upgrade to Paid Decode</a>
       </div>
     </section>
   </main>

--- a/blog/dating-in-your-30s-the-intentional-era.html
+++ b/blog/dating-in-your-30s-the-intentional-era.html
@@ -99,8 +99,8 @@
       <h2>Ready to Decode Your Relationship Patterns?</h2>
       <p class="cta-sub">Start with a free analysis, then go deeper when you’re ready.</p>
       <div class="cta-group">
-        <a class="btn btn-primary" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener noreferrer" data-analytics="cta-free-analysis">Get a Free Analysis</a>
-        <a class="btn btn-accent" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener noreferrer" data-analytics="cta-unlimited">Upgrade to Paid Decode</a>
+        <a class="btn btn-primary" href="/go/free-analysis/" rel="noopener">Get a Free Analysis</a>
+        <a class="btn btn-accent" href="/go/paid-decode/" rel="noopener">Upgrade to Paid Decode</a>
       </div>
     </section>
   </main>

--- a/go/free-analysis/index.html
+++ b/go/free-analysis/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Free Relationship Pattern Analysis • Seen & Red</title>
+  <link rel="stylesheet" href="/styles.css" />
+  <meta name="description" content="Start your free relationship pattern analysis.">
+  <link rel="canonical" href="https://www.seenandred.com/go/free-analysis/">
+</head>
+<body>
+  <main class="sr-cta" style="max-width:780px;margin:4rem auto;">
+    <h1>Free Relationship Pattern Analysis</h1>
+    <p class="cta-sub">This page routes you to our public form. We keep your workspace private.</p>
+    <p>Click below to begin. If you don’t see the form open, your pop-up blocker may be on.</p>
+    <div class="cta-group" style="margin-top:1rem;">
+      <a class="btn btn-primary" href="https://form.jotform.com/252205735289057" target="_blank" rel="noopener">Open Free Analysis Form</a>
+      <a class="btn btn-accent" href="/blog.html">Back to Blog</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/go/paid-decode/index.html
+++ b/go/paid-decode/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Paid Decode • Seen & Red</title>
+  <link rel="stylesheet" href="/styles.css" />
+  <meta name="description" content="Upgrade to a deeper, expert-led relationship decode.">
+  <link rel="canonical" href="https://www.seenandred.com/go/paid-decode/">
+</head>
+<body>
+  <main class="sr-cta" style="max-width:780px;margin:4rem auto;">
+    <h1>Upgrade to Paid Decode</h1>
+    <p class="cta-sub">Get a comprehensive breakdown with tailored guidance and next steps.</p>
+    <div class="cta-group" style="margin-top:1rem;">
+      <a class="btn btn-primary" href="https://pci.jotform.com/form/252205842827054" target="_blank" rel="noopener">Open Paid Decode Form</a>
+      <a class="btn btn-accent" href="/blog.html">Back to Blog</a>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace external Jotform links in dating-in-your-20s and dating-in-your-30s posts with internal `/go` routes.
- Add `/go/free-analysis/` and `/go/paid-decode/` pages as placeholders for future Jotform forms.
- Swap placeholder anchors on the `/go` pages with the actual Jotform URLs.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b155e48dec8326926e588f96056b79