### PR TITLE
Remove papaya image references from blog

### DIFF
--- a/blog/dating-culture/index.html
+++ b/blog/dating-culture/index.html
@@ -30,9 +30,6 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Dating Culture — Social Media, Trends & Crowd Intel">
 <meta property="og:description" content="Social platforms and trends that shape modern dating.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/dating-culture/">
-<meta property="og:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&h=630&fit=crop&q=80">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">{
 "@context":"https://schema.org",
@@ -122,7 +119,6 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     </article>
 
     <article class="card">
-      <a href="/blog/dating-in-the-era-of-social-media.html"><img src="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/dating-in-the-era-of-social-media.html">Dating in the Era of Social Media</a></h3>
         <p>Boundaries that work, red/green DM examples, and how to use group intel without drama.</p>

--- a/blog/dating-in-the-era-of-social-media.html
+++ b/blog/dating-in-the-era-of-social-media.html
@@ -25,9 +25,6 @@ hr{border:0;border-top:1px solid var(--sr-border);margin:28px 0}
 <meta property="og:title" content="Dating in the Era of Social Media">
 <meta property="og:description" content="Boundaries that work, red/green DM examples, and how to use group intel without drama.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/dating-in-the-era-of-social-media.html">
-<meta property="og:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&h=630&fit=crop&q=80">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="/assets/css/styles.css" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Dating in the Era of Social Media","datePublished":"2025-08-20","author":{"@type":"Organization","name":"Seen & Red"},"publisher":{"@type":"Organization","name":"Seen & Red"},"description":"Boundaries that work, red/green DM examples, and how to use group intel without drama."}</script>

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,11 +10,9 @@
   <meta property="og:title" content="Seen &amp; Red Blog">
   <meta property="og:description" content="Seen &amp; Red blog covering modern dating, boundaries, and relationship clarity.">
   <meta property="og:url" content="https://seenandred.com/blog/">
-  <meta property="og:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&h=630&fit=crop&q=80">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Seen &amp; Red Blog">
   <meta name="twitter:description" content="Seen &amp; Red blog covering modern dating, boundaries, and relationship clarity.">
-  <meta name="twitter:image" content="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=1200&h=630&fit=crop&q=80">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Lato:wght@400;500;700&display=swap" rel="stylesheet">
@@ -164,8 +162,7 @@ html,body{margin:0}
 
     <!-- Social Media — Dating Culture -->
     <article class="post-card" data-category="culture">
-      <img class="thumb" src="https://images.unsplash.com/photo-1519335665485-5fdfb92a99d7?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" />
-      <a class="post-link" href="/blog/dating-in-the-era-of-social-media.html?v=18" aria-label="Read: Dating in the Era of Social Media">
+        <a class="post-link" href="/blog/dating-in-the-era-of-social-media.html?v=18" aria-label="Read: Dating in the Era of Social Media">
         <div class="post-body">
           <div class="blog-meta category-culture">Dating Culture</div>
           <h3 class="post-title">Dating in the Era of Social Media</h3>


### PR DESCRIPTION
## Summary
- remove papaya Unsplash thumbnail and social image tags from blog index
- strip papaya image and OG metadata from Dating Culture listing
- delete papaya OG image from Dating in the Era of Social Media article

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2715333a483268671d411153dfeb8