### PR TITLE
Replace papaya Unsplash images with local assets

### DIFF
--- a/blog/healing-your-patterns.html
+++ b/blog/healing-your-patterns.html
@@ -9,7 +9,7 @@
 <meta property="og:title" content="Healing Your Patterns: Breaking the Cycle">
 <meta property="og:description" content="Attachment, trauma bonds, and practical steps to change repeated relationship choices.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/healing-your-patterns.html">
-<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image" content="/assets/images/brokenheart-hero.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">

--- a/blog/index.html
+++ b/blog/index.html
@@ -213,7 +213,7 @@ html,body{margin:0}
 
     <!-- Trust Your Intuition — Patterns & Psychology -->
     <article class="post-card" data-category="psych">
-      <img class="thumb" src="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" />
+      <img class="thumb" src="/assets/images/mujer-joven-concentrada-con-su-telefono-posando-en-casa.jpg" alt="Young woman focused on her phone at home" loading="lazy" />
       <a class="post-link" href="/blog/trust-your-intuition.html?v=18" aria-label="Read: Trust Your Intuition">
         <div class="post-body">
           <div class="blog-meta category-psych">Patterns &amp; Psychology</div>

--- a/blog/patterns-psychology/index.html
+++ b/blog/patterns-psychology/index.html
@@ -30,7 +30,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Patterns & Psychology — Attachment, Intuition & Receipts">
 <meta property="og:description" content="Attachment, intuition vs anxiety, and text-pattern analysis.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/patterns-psychology/">
-<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image" content="/assets/images/brokenheart-hero.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
@@ -93,7 +93,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
     </article>
 
     <article class="card">
-        <a href="/blog/trust-your-intuition.html"><img src="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/trust-your-intuition.html"><img src="/assets/images/mujer-joven-concentrada-con-su-telefono-posando-en-casa.jpg" alt="Young woman focused on her phone at home" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/trust-your-intuition.html">Trust Your Intuition</a></h3>
         <p>A 4‑step gut check to separate intuition from anxiety, with real text examples.</p>

--- a/blog/trust-your-intuition.html
+++ b/blog/trust-your-intuition.html
@@ -9,7 +9,7 @@
 <meta property="og:title" content="Trust Your Intuition">
 <meta property="og:description" content="A quick gut‑check framework to separate intuition from anxiety, with real text examples.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/trust-your-intuition.html">
-<meta property="og:image" content="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image" content="/assets/images/mujer-joven-concentrada-con-su-telefono-posando-en-casa.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
@@ -30,7 +30,7 @@
 </head><body>
 <main class="prose-wrap">
   <figure class="article-hero">
-    <img src="https://images.unsplash.com/photo-1526318472351-c75fcf070305?w=1600&h=900&fit=crop&q=80" alt="Person journaling and thinking">
+    <img src="/assets/images/mujer-joven-concentrada-con-su-telefono-posando-en-casa.jpg" alt="Young woman focused on her phone at home">
   </figure>
 
   <article class="prose">


### PR DESCRIPTION
## Summary
- swap unsplash papaya hero and OpenGraph images for local assets in `healing-your-patterns.html` and `trust-your-intuition.html`
- update blog listing pages to use the new thumbnail image
- set Patterns & Psychology OpenGraph image to local file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28b02dd90832697b3af0e81267fa9