### PR TITLE
Use local image for Missing Green Flags article

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -153,6 +153,7 @@ html,body{margin:0}
     <!-- Missing Green Flags -->
     <article class="post-card">
       <a class="post-link" href="/blog/missing-green-flags.html" aria-label="Read: Missing Green Flags">
+        <img class="post-thumb" src="/assets/images/greenflag-hero.jpg" alt="" loading="lazy">
         <div class="card-header">Green Flags</div>
         <div class="post-body">
           <h3 class="post-title">Missing Green Flags</h3>

--- a/blog/green-flags/index.html
+++ b/blog/green-flags/index.html
@@ -30,7 +30,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Green Flags — What Healthy Looks Like">
 <meta property="og:description" content="Consistency, reciprocity, and safety in action.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/green-flags/">
-<meta property="og:image" content="https://images.unsplash.com/photo-1492496913980-501348b61469?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image" content="/assets/images/greenflag-hero.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
@@ -82,7 +82,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 
   <section class="grid" aria-label="Articles">
     <article class="card">
-        <a href="/blog/missing-green-flags.html"><img src="https://images.unsplash.com/photo-1492496913980-501348b61469?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/missing-green-flags.html"><img src="/assets/images/greenflag-hero.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/missing-green-flags.html">Missing Green Flags</a></h3>
         <p>Why healthy can feel “boring,” plus a checklist for noticing safety and reciprocity.</p>

--- a/blog/index.html
+++ b/blog/index.html
@@ -226,7 +226,7 @@ html,body{margin:0}
 
     <!-- Missing Green Flags — Green Flags -->
     <article class="post-card" data-category="green">
-      <img class="thumb" src="https://images.unsplash.com/photo-1492496913980-501348b61469?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" />
+      <img class="thumb" src="/assets/images/greenflag-hero.jpg" alt="" loading="lazy" />
       <a class="post-link" href="/blog/missing-green-flags.html?v=18" aria-label="Read: Missing Green Flags">
         <div class="post-body">
           <div class="blog-meta category-green">Green Flags</div>

--- a/blog/missing-green-flags.html
+++ b/blog/missing-green-flags.html
@@ -9,7 +9,7 @@
 <meta property="og:title" content="Missing Green Flags">
 <meta property="og:description" content="A checklist for recognizing healthy effort, emotional safety, and reciprocity.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/missing-green-flags.html">
-<meta property="og:image" content="https://images.unsplash.com/photo-1492496913980-501348b61469?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image" content="/assets/images/greenflag-hero.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
@@ -30,7 +30,7 @@
 </head><body>
 <main class="prose-wrap">
   <figure class="article-hero">
-    <img src="https://images.unsplash.com/photo-1492496913980-501348b61469?w=1600&h=900&fit=crop&q=80" alt="Sunlit plants symbolizing healthy growth">
+    <img src="/assets/images/greenflag-hero.jpg" alt="Green flag illustration">
   </figure>
 
   <article class="prose">


### PR DESCRIPTION
## Summary
- Swap out Unsplash image for local `greenflag-hero.jpg` in the "Missing Green Flags" article preview across blog listings.
- Add corresponding thumbnail on the main blog page and update OpenGraph image for green flag content pages.
- Replace hero and OG images on the "Missing Green Flags" article page with the local asset.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28ecca9a88326a0e3f6e578bf3480