### PR TITLE
Use local red flag hero image

### DIFF
--- a/blog/ignoring-red-flags.html
+++ b/blog/ignoring-red-flags.html
@@ -9,7 +9,7 @@
 <meta property="og:title" content="Ignoring Red Flags">
 <meta property="og:description" content="From excuses to standards — spot patterns early and act sooner.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://seenandred.com/blog/ignoring-red-flags.html">
-<meta property="og:image" content="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image" content="/assets/images/redflag-hero.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
@@ -30,7 +30,7 @@
 </head><body>
 <main class="prose-wrap">
   <figure class="article-hero">
-    <img src="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1600&h=900&fit=crop&q=80" alt="Red fabric/flag in motion">
+    <img src="/assets/images/redflag-hero.jpg" alt="Red fabric/flag in motion">
   </figure>
 
   <article class="prose">

--- a/blog/index.html
+++ b/blog/index.html
@@ -239,7 +239,7 @@ html,body{margin:0}
 
     <!-- Ignoring Red Flags — Red Flags -->
     <article class="post-card" data-category="red">
-      <img class="thumb" src="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" />
+      <img class="thumb" src="/assets/images/redflag-hero.jpg" alt="" loading="lazy" />
       <a class="post-link" href="/blog/ignoring-red-flags.html?v=18" aria-label="Read: Ignoring Red Flags">
         <div class="post-body">
           <div class="blog-meta category-red">Red Flags</div>

--- a/blog/red-flags/index.html
+++ b/blog/red-flags/index.html
@@ -30,7 +30,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 <meta property="og:title" content="Red Flag Radar — Articles on Dating Red Flags">
 <meta property="og:description" content="Psych-backed guides and real text examples to spot red flags sooner.">
 <meta property="og:type" content="website"><meta property="og:url" content="https://seenandred.com/blog/red-flags/">
-<meta property="og:image" content="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=1200&h=630&fit=crop&q=80">
+<meta property="og:image" content="/assets/images/redflag-hero.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
@@ -82,7 +82,7 @@ h1,h2{font-family:"Playfair Display",Georgia,serif;line-height:1.2}
 
   <section class="grid" aria-label="Articles">
     <article class="card">
-        <a href="/blog/ignoring-red-flags.html"><img src="https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=800&h=450&fit=crop&q=80" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
+        <a href="/blog/ignoring-red-flags.html"><img src="/assets/images/redflag-hero.jpg" alt="" loading="lazy" style="width:100%;height:auto;aspect-ratio:16/9;object-fit:cover"></a>
       <div class="card-body">
         <h3><a href="/blog/ignoring-red-flags.html">Ignoring Red Flags</a></h3>
         <p>Cognitive dissonance, sunk cost, and how to make standards stick — with healthier script swaps.</p>


### PR DESCRIPTION
## Summary
- Replace Unsplash hero with local `redflag-hero.jpg` on Ignoring Red Flags article
- Update Red Flags index and blog listing cards to use the same local image

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29181f4e883268f7adadd7c9125cb