### PR TITLE
Fix Trust Your Gut link on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,7 +681,7 @@
                     <div class="feature-card">
                         <h3>Trust Your Gut (It's Smarter Than You Think)</h3>
                         <p>That "weird feeling" isn't paranoia—it's your inner wisdom trying to save you from another situationship. Learn when to trust your intuition vs. when it's just anxiety.</p>
-                        <a href="blog/trust-your-intuition.html" style="color: var(--primary-red); text-decoration: none; font-weight: 600;">Listen to Yourself →</a>
+                        <a href="/blog/trust-your-intuition.html" style="color: var(--primary-red); text-decoration: none; font-weight: 600;">Listen to Yourself →</a>
                     </div>
                     <div class="feature-card">
                         <h3>Healing Your Patterns (Finally)</h3>


### PR DESCRIPTION
## Summary
- Fix "Trust Your Gut" card to point to `/blog/trust-your-intuition.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29443861883269733e0384c99c947